### PR TITLE
fix(devtools): a lot of extension server error: Operation failed: Permission denied

### DIFF
--- a/src/main-app/src/utils/WindowEvent.ts
+++ b/src/main-app/src/utils/WindowEvent.ts
@@ -15,3 +15,13 @@ export const windowReadyToShow = (customWindow: CustomSingleWindow) => {
         customWindow.window.show();
     });
 };
+
+export const windowOpenDevTools = (customWindow: CustomSingleWindow) => {
+    customWindow.window.webContents.once("dom-ready", () => {
+        // open devTools must be completed after dom ready
+        // link: https://github.com/electron/electron/issues/12438
+        if (customWindow.options.isOpenDevTools) {
+            customWindow.window.webContents.openDevTools();
+        }
+    });
+};

--- a/src/main-app/src/utils/WindowManager.ts
+++ b/src/main-app/src/utils/WindowManager.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain, IpcMainEvent } from "electron";
-import { windowHookClose, windowReadyToShow } from "./WindowEvent";
+import { windowHookClose, windowOpenDevTools, windowReadyToShow } from "./WindowEvent";
 import runtime from "./Runtime";
 import { constants } from "types-pkg";
 import { Subject, zip } from "rxjs";
@@ -57,9 +57,7 @@ export class WindowManager {
 
         void innerWin.window.loadURL(options.url);
 
-        if (options.isOpenDevTools) {
-            innerWin.window.webContents.openDevTools();
-        }
+        windowOpenDevTools(innerWin);
 
         windowHookClose(innerWin);
 


### PR DESCRIPTION
1. before the console opens DevTools, the dom has not been loaded, and
   many DevTools errors will appear.