### PR TITLE
refactor(flat-components): use promise in validator

### DIFF
--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderBeginTimePicker.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderBeginTimePicker.tsx
@@ -34,10 +34,11 @@ export function renderBeginTimePicker(
 
     function validateTime(): RuleObject {
         return {
-            validator: (_, value: Date): void => {
+            validator(_, value: Date): Promise<void> {
                 if (isBefore(value, getRoughNow())) {
                     throw new Error(t("begin-time-cannot-be-in-the-past"));
                 }
+                return Promise.resolve();
             },
         };
     }

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderEndTimePicker.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderEndTimePicker.tsx
@@ -25,12 +25,13 @@ export function renderEndTimePicker(
 
     function validateTime(): RuleObject {
         return {
-            validator: (_, value: Date): void => {
+            validator: (_, value: Date): Promise<void> => {
                 const beginTime: EditRoomFormValues["beginTime"] = form.getFieldValue("beginTime");
                 const compareTime = addMinutes(beginTime, MIN_CLASS_DURATION);
                 if (isBefore(value, compareTime)) {
                     throw new Error(t("room-duration-limit", { minutes: MIN_CLASS_DURATION }));
                 }
+                return Promise.resolve();
             },
         };
     }

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderPeriodicForm.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderPeriodicForm.tsx
@@ -179,7 +179,7 @@ export const renderPeriodicForm = (t: TFunction<string>, lang: string) =>
 
         function validatePeriodicEndTime(): RuleObject {
             return {
-                validator: (_, value: Date): void => {
+                validator: (_, value: Date): Promise<void> => {
                     const {
                         periodic,
                         beginTime,
@@ -197,6 +197,7 @@ export const renderPeriodicForm = (t: TFunction<string>, lang: string) =>
                             t("end-series-date-cannot-be-less-than-the-begin-time-date"),
                         );
                     }
+                    return Promise.resolve();
                 },
             };
         }


### PR DESCRIPTION
because  validator of field-form rules was changed.

Details：https://github.com/react-component/field-form/blame/a3b1bfa477964934eaa49f8adf233e8a1d691298/src/utils/validateUtil.ts#L158.