### PR TITLE
docs(readme): split environment variable reference

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -80,39 +80,18 @@ yarn run start
 -   项目根执行 `yarn ship` 将根据当前系统打包。
 -   或者项目根执行 `yarn ship:mac` 或 `yarn ship:win` 可针对相应系统打包。
 
-## Storybook
+### Storybook
 
 部分 Flat 组件 UI 可通过 Storybook 快速查看与开发（[线上地址][flat-storybook]）。
 
 -   项目根执行 `yarn run storybook` 可在本地运行 Storybook。
 
-## 环境变量值参考
+## 文档
 
-| 变量名                               | 描述                                               | 备注                                                             |
-| ------------------------------------ | -------------------------------------------------- | ---------------------------------------------------------------- |
-| NETLESS_APP_IDENTIFIER               | 互动白板 Access Key                                | 见: [在 app 服务端生成 Token][netless-auth]                      |
-| AGORA_APP_ID                         | Agora 声网 App ID                                  | 用于 RTC 与 RTM。见: [校验用户权限][agora-app-id-auth]           |
-| CLOUD_STORAGE_OSS_ALIBABA_ACCESS_KEY | Agora 云端录制 OSS 配置                            | 用于云端录制存储用户音视频。见: [云存储设置][cloud-recording]    |
-| CLOUD_STORAGE_OSS_ALIBABA_BUCKET     | Agora 云端录制 OSS 配置                            | 同上                                                             |
-| CLOUD_STORAGE_OSS_ALIBABA_REGION     | Agora 云端录制 OSS 配置                            | 同上                                                             |
-| CLOUD_RECORDING_DEFAULT_AVATAR       | Agora 云端录制用户默认背景图 URL                   | 见：[设置背景色或背景图][cloud-recording-background]             |
-| WECHAT_APP_ID                        | [微信开放平台][open-wechat] App ID                 | 见 `网站应用` 里 `AppID`                                         |
-| FLAT_SERVER_DOMAIN                   | Flat Server 部署的域名地址                         | 如: `flat-api.whiteboard.agora.io`                               |
-| UPDATE_DOMAIN                        | Flat 升级的 OSS 域名地址，用于存放新版与历史安装包 | 如: `https://flat-storage.oss-cn-hangzhou.aliyuncs.com/versions` |
-| SKIP_MAC_NOTARIZE                    | 是否跳过 Mac 公证步骤                              | 值: `yes` 或者 `no`                                              |
-| APPLE_API_ISSUER                     | Apple 公证的 issuer，可选，留空时不做公证          | 详情见: [electron-updater][electron-updater]                     |
-| APPLE_API_KEY                        | Apple 公证的 key，可选，留空时不做公证             | 详情见: [electron-updater][electron-updater]                     |
-| WINDOWS_CODE_SIGNING_CA_PATH         | Windows 签名证书文件路径，可选，留空时不做签名     | 相对路径，相对于 `desktop/main-app` 目录                         |
-| WINDOWS_CODE_SIGNING_CA_PASSWORD     | Windows 签名证书密码，可选，留空时不做签名         |                                                                  |
+* [环境变量值参考](docs/env/README-zh.md)
 
 [flat-homepage]: https://flat.whiteboard.agora.io/#download
 [flat-web]: https://flat-web.whiteboard.agora.io/
 [flat-server]: https://github.com/netless-io/flat-server
 [flat-android]: https://github.com/netless-io/flat-android
 [flat-storybook]: https://netless-io.github.io/flat/
-[open-wechat]: https://open.weixin.qq.com/
-[netless-auth]: https://docs.agora.io/cn/whiteboard/generate_whiteboard_token_at_app_server?platform=RESTful
-[agora-app-id-auth]: https://docs.agora.io/cn/Agora%20Platform/token#a-name--appidause-an-app-id-for-authentication
-[cloud-recording]: https://docs.agora.io/cn/cloud-recording/cloud_recording_api_rest?platform=RESTful#storageConfig
-[cloud-recording-background]: https://docs.agora.io/cn/cloud-recording/cloud_recording_layout?platform=RESTful#background
-[electron-updater]: https://github.com/electron-userland/electron-builder/tree/master/packages/electron-updater

--- a/README.md
+++ b/README.md
@@ -87,33 +87,12 @@ Many Flat components UI can be quickly viewed and developed via Storybook ([Onli
 
 -   Run `yarn run storybook` at project root to run Storybook locally.
 
-## Environment Variables Reference
+## Documents
 
-| Variable                             | Description                                              | Note                                                                                |
-| ------------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| NETLESS_APP_IDENTIFIER               | Whiteboard Access Key                                    | See [Projects and permissions][netless-auth]                                        |
-| AGORA_APP_ID                         | Agora App ID                                             | For RTC and RTM. See [Use an App ID for authentication][agora-app-id-auth]          |
-| CLOUD_STORAGE_OSS_ALIBABA_ACCESS_KEY | Agora Cloud Recording OSS                                | For storing RTC Cloud Recording media files. See [Cloud Recording][cloud-recording] |
-| CLOUD_STORAGE_OSS_ALIBABA_BUCKET     | Agora Cloud Recording OSS                                | As above                                                                            |
-| CLOUD_STORAGE_OSS_ALIBABA_REGION     | Agora Cloud Recording OSS                                | As above                                                                            |
-| CLOUD_RECORDING_DEFAULT_AVATAR       | Agora Cloud Recording default user avatar URL            | See: [Set the background color or background image][cloud-recording-background]     |
-| WECHAT_APP_ID                        | [Wechat Open Platform][open-wechat] App ID               |                                                                                     |
-| FLAT_SERVER_DOMAIN                   | Flat Server deployed address                             | e.g. `flat-api.whiteboard.agora.io`                                                 |
-| UPDATE_DOMAIN                        | Flat upgrade OSS address for storing artifacts           | e.g. `https://flat-storage.oss-cn-hangzhou.aliyuncs.com/versions`                   |
-| SKIP_MAC_NOTARIZE                    | Whether to skip the mac notarization step                | value: `yes` or `no`                                                                |
-| APPLE_API_ISSUER                     | Apple notarizing issuer. Skip notarizing if not provided | See: [electron-updater][electron-updater]                                           |
-| APPLE_API_KEY                        | Apple notarizing key. Skip notarizing if not provided    | See: [electron-updater][electron-updater]                                           |
-| WINDOWS_CODE_SIGNING_CA_PATH         | Windows Code Signing CA file path. Skip if not provided  | Relative to `desktop/main-app`                                                      |
-| WINDOWS_CODE_SIGNING_CA_PASSWORD     | Windows Code Signing CA password. Skip if not provided   |                                                                                     |
+* [Environment Variables Reference](docs/env/README.md)
 
 [flat-homepage]: https://flat.whiteboard.agora.io/en/#download
 [flat-web]: https://flat-web.whiteboard.agora.io/
 [flat-server]: https://github.com/netless-io/flat-server
 [flat-android]: https://github.com/netless-io/flat-android
 [flat-storybook]: https://netless-io.github.io/flat/
-[open-wechat]: https://open.weixin.qq.com/
-[netless-auth]: https://docs.agora.io/en/whiteboard/generate_whiteboard_token_at_app_server?platform=RESTful
-[agora-app-id-auth]: https://docs.agora.io/en/Agora%20Platform/token#a-name--appidause-an-app-id-for-authentication
-[cloud-recording]: https://docs.agora.io/en/cloud-recording/cloud_recording_api_rest?platform=RESTful#storageConfig
-[cloud-recording-background]: https://docs.agora.io/en/cloud-recording/cloud_recording_layout?platform=RESTful#background
-[electron-updater]: https://github.com/electron-userland/electron-builder/tree/master/packages/electron-updater

--- a/docs/env/README-zh.md
+++ b/docs/env/README-zh.md
@@ -1,0 +1,25 @@
+## 环境变量值参考
+
+| 变量名                               | 描述                                               | 备注                                                             |
+| ------------------------------------ | -------------------------------------------------- | ---------------------------------------------------------------- |
+| NETLESS_APP_IDENTIFIER               | 互动白板 Access Key                                | 见: [在 app 服务端生成 Token][netless-auth]                      |
+| AGORA_APP_ID                         | Agora 声网 App ID                                  | 用于 RTC 与 RTM。见: [校验用户权限][agora-app-id-auth]           |
+| CLOUD_STORAGE_OSS_ALIBABA_ACCESS_KEY | Agora 云端录制 OSS 配置                            | 用于云端录制存储用户音视频。见: [云存储设置][cloud-recording]    |
+| CLOUD_STORAGE_OSS_ALIBABA_BUCKET     | Agora 云端录制 OSS 配置                            | 同上                                                             |
+| CLOUD_STORAGE_OSS_ALIBABA_REGION     | Agora 云端录制 OSS 配置                            | 同上                                                             |
+| CLOUD_RECORDING_DEFAULT_AVATAR       | Agora 云端录制用户默认背景图 URL                   | 见：[设置背景色或背景图][cloud-recording-background]             |
+| WECHAT_APP_ID                        | [微信开放平台][open-wechat] App ID                 | 见 `网站应用` 里 `AppID`                                         |
+| FLAT_SERVER_DOMAIN                   | Flat Server 部署的域名地址                         | 如: `flat-api.whiteboard.agora.io`                               |
+| UPDATE_DOMAIN                        | Flat 升级的 OSS 域名地址，用于存放新版与历史安装包 | 如: `https://flat-storage.oss-cn-hangzhou.aliyuncs.com/versions` |
+| SKIP_MAC_NOTARIZE                    | 是否跳过 Mac 公证步骤                              | 值: `yes` 或者 `no`                                              |
+| APPLE_API_ISSUER                     | Apple 公证的 issuer，可选，留空时不做公证          | 详情见: [electron-updater][electron-updater]                     |
+| APPLE_API_KEY                        | Apple 公证的 key，可选，留空时不做公证             | 详情见: [electron-updater][electron-updater]                     |
+| WINDOWS_CODE_SIGNING_CA_PATH         | Windows 签名证书文件路径，可选，留空时不做签名     | 相对路径，相对于 `desktop/main-app` 目录                         |
+| WINDOWS_CODE_SIGNING_CA_PASSWORD     | Windows 签名证书密码，可选，留空时不做签名         |                                                                  |
+
+[open-wechat]: https://open.weixin.qq.com/
+[netless-auth]: https://docs.agora.io/cn/whiteboard/generate_whiteboard_token_at_app_server?platform=RESTful
+[agora-app-id-auth]: https://docs.agora.io/cn/Agora%20Platform/token#a-name--appidause-an-app-id-for-authentication
+[cloud-recording]: https://docs.agora.io/cn/cloud-recording/cloud_recording_api_rest?platform=RESTful#storageConfig
+[cloud-recording-background]: https://docs.agora.io/cn/cloud-recording/cloud_recording_layout?platform=RESTful#background
+[electron-updater]: https://github.com/electron-userland/electron-builder/tree/master/packages/electron-updater

--- a/docs/env/README.md
+++ b/docs/env/README.md
@@ -1,0 +1,25 @@
+## Environment Variables Reference
+
+| Variable                             | Description                                              | Note                                                                                |
+| ------------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| NETLESS_APP_IDENTIFIER               | Whiteboard Access Key                                    | See [Projects and permissions][netless-auth]                                        |
+| AGORA_APP_ID                         | Agora App ID                                             | For RTC and RTM. See [Use an App ID for authentication][agora-app-id-auth]          |
+| CLOUD_STORAGE_OSS_ALIBABA_ACCESS_KEY | Agora Cloud Recording OSS                                | For storing RTC Cloud Recording media files. See [Cloud Recording][cloud-recording] |
+| CLOUD_STORAGE_OSS_ALIBABA_BUCKET     | Agora Cloud Recording OSS                                | As above                                                                            |
+| CLOUD_STORAGE_OSS_ALIBABA_REGION     | Agora Cloud Recording OSS                                | As above                                                                            |
+| CLOUD_RECORDING_DEFAULT_AVATAR       | Agora Cloud Recording default user avatar URL            | See: [Set the background color or background image][cloud-recording-background]     |
+| WECHAT_APP_ID                        | [Wechat Open Platform][open-wechat] App ID               |                                                                                     |
+| FLAT_SERVER_DOMAIN                   | Flat Server deployed address                             | e.g. `flat-api.whiteboard.agora.io`                                                 |
+| UPDATE_DOMAIN                        | Flat upgrade OSS address for storing artifacts           | e.g. `https://flat-storage.oss-cn-hangzhou.aliyuncs.com/versions`                   |
+| SKIP_MAC_NOTARIZE                    | Whether to skip the mac notarization step                | value: `yes` or `no`                                                                |
+| APPLE_API_ISSUER                     | Apple notarizing issuer. Skip notarizing if not provided | See: [electron-updater][electron-updater]                                           |
+| APPLE_API_KEY                        | Apple notarizing key. Skip notarizing if not provided    | See: [electron-updater][electron-updater]                                           |
+| WINDOWS_CODE_SIGNING_CA_PATH         | Windows Code Signing CA file path. Skip if not provided  | Relative to `desktop/main-app`                                                      |
+| WINDOWS_CODE_SIGNING_CA_PASSWORD     | Windows Code Signing CA password. Skip if not provided   |                                                                                     |
+
+[open-wechat]: https://open.weixin.qq.com/
+[netless-auth]: https://docs.agora.io/en/whiteboard/generate_whiteboard_token_at_app_server?platform=RESTful
+[agora-app-id-auth]: https://docs.agora.io/en/Agora%20Platform/token#a-name--appidause-an-app-id-for-authentication
+[cloud-recording]: https://docs.agora.io/en/cloud-recording/cloud_recording_api_rest?platform=RESTful#storageConfig
+[cloud-recording-background]: https://docs.agora.io/en/cloud-recording/cloud_recording_layout?platform=RESTful#background
+[electron-updater]: https://github.com/electron-userland/electron-builder/tree/master/packages/electron-updater


### PR DESCRIPTION
because they are not must-know, lower their priority

Adjust the priority of `storybook` at the same time