### PR TITLE
refactor(renderer-app): hide share screen picker scrollbar

### DIFF
--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/style.less
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/style.less
@@ -18,6 +18,10 @@
     height: 450px;
     overflow-y: scroll;
 
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
     &.loading {
         display: flex;
         justify-content: center;


### PR DESCRIPTION
because it is displayed too ugly on windows