### PR TITLE
chore(yarn): drop `.yarnrc`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-electron_mirror "http://npm.taobao.org/mirrors/electron/"


### PR DESCRIPTION
Not everyone needs this configuration.

You could move this file to `~/.yarnrc` if your team need some "network speed up".