### PR TITLE
chore(storybook): drop deprecated Faker API usages

### DIFF
--- a/packages/flat-components/src/components/ChatPanel/ChatMessage/ChatMessage.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessage/ChatMessage.stories.tsx
@@ -22,8 +22,8 @@ Overview.args = {
     message: {
         timestamp: +faker.date.past(),
         type: ChatMsgType.ChannelMessage,
-        userUUID: faker.random.boolean() ? userUUID : faker.datatype.uuid(),
+        userUUID: faker.datatype.boolean() ? userUUID : faker.datatype.uuid(),
         uuid: faker.datatype.uuid(),
-        value: chance.sentence({ words: faker.random.number(20) }),
+        value: chance.sentence({ words: faker.datatype.number(20) }),
     },
 };

--- a/packages/flat-components/src/components/ChatPanel/ChatMessageList/ChatMessageList.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessageList/ChatMessageList.stories.tsx
@@ -23,8 +23,8 @@ export const Overview: Story<ChatMessageListProps> = args => (
 const makeUser = (): User => ({
     userUUID: faker.datatype.uuid(),
     name: faker.name.lastName(),
-    isSpeak: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
+    isSpeak: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
     avatar: "http://placekitten.com/64/64",
 });
 const currentUser = makeUser();
@@ -43,7 +43,7 @@ Overview.args = {
             type: ChatMsgType.ChannelMessage,
             userUUID: chance.pickone(users).userUUID,
             uuid: faker.datatype.uuid(),
-            value: chance.sentence({ words: faker.random.number(20) }),
+            value: chance.sentence({ words: faker.datatype.number(20) }),
         })),
     getUserByUUID: uuid => users.find(e => e.userUUID === uuid) || makeUser(),
 };

--- a/packages/flat-components/src/components/ChatPanel/ChatMessages/ChatMessages.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessages/ChatMessages.stories.tsx
@@ -23,8 +23,8 @@ export const Overview: Story<ChatMessagesProps> = args => (
 const makeUser = (): User => ({
     userUUID: faker.datatype.uuid(),
     name: faker.name.lastName(),
-    isSpeak: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
+    isSpeak: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
     avatar: "http://placekitten.com/64/64",
 });
 const currentUser = makeUser();
@@ -43,7 +43,7 @@ Overview.args = {
             type: ChatMsgType.ChannelMessage,
             userUUID: chance.pickone(users).userUUID,
             uuid: faker.datatype.uuid(),
-            value: chance.sentence({ words: faker.random.number(20) }),
+            value: chance.sentence({ words: faker.datatype.number(20) }),
         })),
     getUserByUUID: uuid => users.find(e => e.userUUID === uuid) || makeUser(),
 };

--- a/packages/flat-components/src/components/ChatPanel/ChatPanel.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatPanel.stories.tsx
@@ -23,8 +23,8 @@ export const Overview: Story<ChatPanelProps> = args => (
 const makeUser = (): User => ({
     userUUID: faker.datatype.uuid(),
     name: faker.name.lastName(),
-    isSpeak: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
+    isSpeak: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
     avatar: "http://placekitten.com/64/64",
 });
 const currentUser = makeUser();
@@ -34,13 +34,13 @@ const users = (() => {
     return chance.shuffle(users);
 })();
 Overview.args = {
-    unreadCount: faker.random.number(),
-    isCreator: faker.random.boolean(),
-    isBan: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
-    hasHandRaising: faker.random.boolean(),
-    hasSpeaking: faker.random.boolean(),
-    disableHandRaising: faker.random.boolean(),
+    unreadCount: faker.datatype.number(),
+    isCreator: faker.datatype.boolean(),
+    isBan: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
+    hasHandRaising: faker.datatype.boolean(),
+    hasSpeaking: faker.datatype.boolean(),
+    disableHandRaising: faker.datatype.boolean(),
     generateAvatar: () => "http://placekitten.com/64/64",
     getUserByUUID: uuid => users.find(e => e.userUUID === uuid) || makeUser(),
     messages: Array(20)
@@ -50,7 +50,7 @@ Overview.args = {
             type: ChatMsgType.ChannelMessage,
             userUUID: chance.pickone(users).userUUID,
             uuid: faker.datatype.uuid(),
-            value: chance.sentence({ words: faker.random.number(20) }),
+            value: chance.sentence({ words: faker.datatype.number(20) }),
         })),
     ownerUUID: faker.datatype.uuid(),
     userUUID: currentUser.userUUID,

--- a/packages/flat-components/src/components/ChatPanel/ChatTabTitle/ChatTabTitle.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTabTitle/ChatTabTitle.stories.tsx
@@ -12,7 +12,7 @@ export default storyMeta;
 
 export const Overview: Story<ChatTabTitleProps> = args => <ChatTabTitle {...args} />;
 Overview.args = {
-    unreadCount: faker.random.number(20),
+    unreadCount: faker.datatype.number(20),
 };
 Overview.argTypes = {
     unreadCount: { control: { type: "number" } },

--- a/packages/flat-components/src/components/ChatPanel/ChatUser/ChatUser.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUser/ChatUser.stories.tsx
@@ -15,8 +15,8 @@ export const Overview: Story<ChatUserProps> = args => <ChatUser {...args} />;
 const makeUser = (): User => ({
     userUUID: faker.datatype.uuid(),
     name: faker.name.lastName(),
-    isSpeak: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
+    isSpeak: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
     avatar: "http://placekitten.com/64/64",
 });
 Overview.args = {

--- a/packages/flat-components/src/components/ChatPanel/ChatUsers/ChatUsers.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUsers/ChatUsers.stories.tsx
@@ -22,8 +22,8 @@ export const Overview: Story<ChatUsersProps> = args => (
 const makeUser = (): User => ({
     userUUID: faker.datatype.uuid(),
     name: faker.name.lastName(),
-    isSpeak: faker.random.boolean(),
-    isRaiseHand: faker.random.boolean(),
+    isSpeak: faker.datatype.boolean(),
+    isRaiseHand: faker.datatype.boolean(),
     avatar: "http://placekitten.com/64/64",
 });
 const currentUser = makeUser();
@@ -35,6 +35,6 @@ const users = ((n: number) => {
 Overview.args = {
     users,
     generateAvatar: () => "http://placekitten.com/64/64",
-    ownerUUID: faker.random.boolean() ? currentUser.userUUID : chance.pickone(users).userUUID,
-    userUUID: faker.random.boolean() ? currentUser.userUUID : chance.pickone(users).userUUID,
+    ownerUUID: faker.datatype.boolean() ? currentUser.userUUID : chance.pickone(users).userUUID,
+    userUUID: faker.datatype.boolean() ? currentUser.userUUID : chance.pickone(users).userUUID,
 };

--- a/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/BigVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/BigVideoAvatar.stories.tsx
@@ -13,12 +13,12 @@ export default storyMeta;
 export const Overview: Story<BigVideoAvatarProps> = args => <BigVideoAvatar {...args} />;
 Overview.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     mini: false,
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.name.lastName(20),
         userUUID: "",
@@ -31,12 +31,12 @@ Overview.argTypes = {
 export const Mini: Story<BigVideoAvatarProps> = args => <BigVideoAvatar {...args} />;
 Mini.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     mini: true,
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.name.lastName(20),
         userUUID: "",
@@ -50,12 +50,12 @@ Mini.argTypes = {
 export const LongUserName: Story<BigVideoAvatarProps> = args => <BigVideoAvatar {...args} />;
 LongUserName.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     mini: false,
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.random.words(20),
         userUUID: "",
@@ -68,7 +68,7 @@ LongUserName.argTypes = {
 export const Placeholder: Story<BigVideoAvatarProps> = args => <BigVideoAvatar {...args} />;
 Placeholder.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
 };
 Placeholder.argTypes = {

--- a/packages/flat-components/src/components/ClassroomPage/NetworkStatus/NetworkStatus.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/NetworkStatus/NetworkStatus.stories.tsx
@@ -13,8 +13,8 @@ export default storyMeta;
 export const Overview: Story<NetworkStatusProps> = args => <NetworkStatus {...args} />;
 Overview.args = {
     networkQuality: {
-        delay: faker.random.number({ min: 0, max: 1000 }),
-        downlink: faker.random.number({ min: 0, max: 8 }),
-        uplink: faker.random.number({ min: 0, max: 8 }),
+        delay: faker.datatype.number({ min: 0, max: 1000 }),
+        downlink: faker.datatype.number({ min: 0, max: 8 }),
+        uplink: faker.datatype.number({ min: 0, max: 8 }),
     },
 };

--- a/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/OneToOneVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/OneToOneVideoAvatar.stories.tsx
@@ -13,11 +13,11 @@ export default storyMeta;
 export const Overview: Story<OneToOneVideoAvatarProps> = args => <OneToOneVideoAvatar {...args} />;
 Overview.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.name.lastName(20),
         userUUID: "",
@@ -38,11 +38,11 @@ export const Pair: Story<OneToOneVideoAvatarProps> = args => {
 };
 Pair.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.name.lastName(20),
         userUUID: "",
@@ -57,11 +57,11 @@ export const LongUserName: Story<OneToOneVideoAvatarProps> = args => (
 );
 LongUserName.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.random.words(20),
         userUUID: "",
@@ -76,7 +76,7 @@ export const Placeholder: Story<OneToOneVideoAvatarProps> = args => (
 );
 Placeholder.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: undefined,
 };

--- a/packages/flat-components/src/components/ClassroomPage/RecordButton/RecordButton.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RecordButton/RecordButton.stories.tsx
@@ -12,6 +12,6 @@ export default storyMeta;
 
 export const Overview: Story<RecordButtonProps> = args => <RecordButton {...args} />;
 Overview.args = {
-    disabled: faker.random.boolean(),
-    isRecording: faker.random.boolean(),
+    disabled: faker.datatype.boolean(),
+    isRecording: faker.datatype.boolean(),
 };

--- a/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/SmallVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/SmallVideoAvatar.stories.tsx
@@ -13,11 +13,11 @@ export default storyMeta;
 export const Overview: Story<SmallVideoAvatarProps> = args => <SmallVideoAvatar {...args} />;
 Overview.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.name.lastName(20),
         userUUID: "",
@@ -31,11 +31,11 @@ Overview.argTypes = {
 export const LongUserName: Story<SmallVideoAvatarProps> = args => <SmallVideoAvatar {...args} />;
 LongUserName.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: {
         avatar: "http://placekitten.com/64/64",
-        mic: faker.random.boolean(),
+        mic: faker.datatype.boolean(),
         camera: false,
         name: faker.random.words(20),
         userUUID: "",
@@ -48,7 +48,7 @@ LongUserName.argTypes = {
 export const Placeholder: Story<SmallVideoAvatarProps> = args => <SmallVideoAvatar {...args} />;
 Placeholder.args = {
     userUUID: "",
-    isCreator: faker.random.boolean(),
+    isCreator: faker.datatype.boolean(),
     children: null,
     avatarUser: undefined,
 };

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/TopBarRightBtn.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/TopBarRightBtn.stories.tsx
@@ -14,6 +14,6 @@ export default storyMeta;
 export const Overview: Story<TopBarRightBtnProps> = args => <TopBarRightBtn {...args} />;
 Overview.args = {
     title: "Hello, world",
-    disabled: faker.random.boolean(),
+    disabled: faker.datatype.boolean(),
     icon: <UserAddOutlined />,
 };

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/TopBarRoundBtn.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/TopBarRoundBtn.stories.tsx
@@ -13,7 +13,7 @@ export default storyMeta;
 
 export const Overview: Story<TopBarRoundBtnProps> = args => <TopBarRoundBtn {...args} />;
 Overview.args = {
-    dark: faker.random.boolean(),
+    dark: faker.datatype.boolean(),
     icon: <UserAddOutlined />,
     className: "pa2",
     children: "Hello, world!",

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/CloudStorageUploadTitle.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/CloudStorageUploadTitle.stories.tsx
@@ -18,7 +18,7 @@ export const Overview: Story<CloudStorageUploadTitleProps> = args => (
     <CloudStorageUploadTitle {...args} />
 );
 Overview.args = {
-    finishWithError: faker.random.boolean(),
+    finishWithError: faker.datatype.boolean(),
     total: chance.integer({ min: 0, max: 200 }),
 };
 Overview.args.finished = chance.integer({ min: 0, max: Overview.args.total! });

--- a/packages/flat-components/src/components/HomePage/RoomList/RoomListItem.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomListItem.stories.tsx
@@ -23,7 +23,7 @@ Overview.args = {
         ],
         { key: "enter", text: "进入" },
     ],
-    isPeriodic: faker.random.boolean(),
+    isPeriodic: faker.datatype.boolean(),
 };
 Overview.argTypes = {
     beginTime: { control: "date" },
@@ -44,7 +44,7 @@ LongRoomName.args = {
         ],
         { key: "enter", text: "进入" },
     ],
-    isPeriodic: faker.random.boolean(),
+    isPeriodic: faker.datatype.boolean(),
 };
 LongRoomName.argTypes = {
     title: { table: { category: "Showcase" } },


### PR DESCRIPTION
`faker.random.number()` and `faker.random.boolean()` has been deprecated. We should use `faker.datatype` instead.

FYI:

- `faker.random.number()`: https://github.com/Marak/faker.js/blob/29234378807c4141588861f69421bf20b5ac635e/lib/random.js#L37
- `faker.random.boolean()`: https://github.com/Marak/faker.js/blob/29234378807c4141588861f69421bf20b5ac635e/lib/random.js#L131