### PR TITLE
chore(eslint): add `eslint-plugin-eslint-comments`

### DIFF
--- a/.eslint.common.js
+++ b/.eslint.common.js
@@ -12,8 +12,9 @@ const eslintCommon = {
             "plugin:@typescript-eslint/recommended",
             "plugin:@typescript-eslint/recommended-requiring-type-checking",
             "plugin:prettier/recommended",
+            "plugin:eslint-comments/recommended"
         ],
-        plugins: ["@netless", "prettier", "@typescript-eslint"],
+        plugins: ["@netless", "prettier", "@typescript-eslint", "eslint-comments"],
         rules: {
             "array-callback-return": "warn",
             "default-case": "off",

--- a/desktop/main-app/package.json
+++ b/desktop/main-app/package.json
@@ -46,6 +46,7 @@
     "electron-notarize": "^1.0.0",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-webpack-plugin": "^3.0.1",
     "file-loader": "^6.2.0",

--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -76,6 +76,7 @@
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",

--- a/desktop/renderer-app/src/components/MainPageLayoutContainer/index.tsx
+++ b/desktop/renderer-app/src/components/MainPageLayoutContainer/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import homeSVG from "./icons/home.svg";
 import homeActiveSVG from "./icons/home-active.svg";
 import diskSVG from "./icons/disk.svg";

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/DeviceCheckLayoutContainer.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/DeviceCheckLayoutContainer.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import systemSVG from "./icons/system.svg";
 import cameraSVG from "./icons/camera.svg";
 import speakerSVG from "./icons/speaker.svg";

--- a/desktop/renderer-app/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
+++ b/desktop/renderer-app/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import generalSVG from "./icons/general.svg";
 import aboutSVG from "./icons/about.svg";
 import hotkeySVG from "./icons/hotkey.svg";

--- a/desktop/renderer-app/src/stores/room-store.ts
+++ b/desktop/renderer-app/src/stores/room-store.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-redeclare */
+/* eslint no-redeclare: off */
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { Region } from "flat-components";
 import {

--- a/packages/flat-components/package.json
+++ b/packages/flat-components/package.json
@@ -59,6 +59,7 @@
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-app": "^6.2.2",

--- a/packages/flat-components/src/components/LoginPage/LoginContent/index.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginContent/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/jsx-no-target-blank */
+/* eslint react/jsx-no-target-blank: off */
 import logoSVG from "./icons/logo.svg";
 import "./index.less";
 

--- a/packages/flat-components/src/components/MainPageLayout/MainPageLayout.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageLayout.stories.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
 import { MainPageLayout, MainPageLayoutProps } from ".";

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNav/MainPageNav.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNav/MainPageNav.stories.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
 import { MainPageNav, MainPageNavProps } from ".";

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/MainPageNavAvatar.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/MainPageNavAvatar.stories.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
 import { MainPageNavAvatar, MainPageNavAvatarProps } from ".";

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/MainPageNavHorizontal.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/MainPageNavHorizontal.stories.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
 import { MainPageNavHorizontal, MainPageNavHorizontalProps } from ".";

--- a/packages/flat-components/src/components/MainPageLayoutHorizontal/MainPageLayoutHorizontal.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayoutHorizontal/MainPageLayoutHorizontal.stories.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
 import { MainPageLayoutHorizontal, MainPageLayoutHorizontalProps } from ".";

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -23,6 +23,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-loader": "^4.0.2",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",

--- a/web/flat-web/src/api-middleware/SmartPlayer.ts
+++ b/web/flat-web/src/api-middleware/SmartPlayer.ts
@@ -290,7 +290,7 @@ export class SmartPlayer extends EventEmitter<SmartPlayerEventType> {
         if (this.combinePlayer) {
             this.combinePlayer.seek(ms);
         } else {
-            whiteboardPlayer.seekToProgressTime(ms);
+            void whiteboardPlayer.seekToProgressTime(ms);
         }
     }
 

--- a/web/flat-web/src/components/MainPageLayoutHorizontalContainer/index.tsx
+++ b/web/flat-web/src/components/MainPageLayoutHorizontalContainer/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 // import deviceSVG from "./icons/device.svg";
 // import deviceActiveSVG from "./icons/device-active.svg";
 import downloadSVG from "./icons/download.svg";

--- a/web/flat-web/src/pages/JoinPage/JoinPageDesktop.tsx
+++ b/web/flat-web/src/pages/JoinPage/JoinPageDesktop.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/jsx-no-target-blank */
+/* eslint react/jsx-no-target-blank: off */
 import logoSVG from "./icons/logo.svg";
 import downloadSVG from "./icons/download.svg";
 import joinSVG from "./icons/join.svg";

--- a/web/flat-web/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
+++ b/web/flat-web/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/display-name */
+/* eslint react/display-name: off */
 import generalSVG from "./icons/general.svg";
 import aboutSVG from "./icons/about.svg";
 import hotkeySVG from "./icons/hotkey.svg";

--- a/web/flat-web/src/stores/room-store.ts
+++ b/web/flat-web/src/stores/room-store.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-redeclare */
+/* eslint no-redeclare: off */
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { Region } from "flat-components";
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7582,6 +7582,14 @@ eslint-module-utils@^2.6.2:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 "eslint-plugin-flowtype@3.x || 4.x":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.7.0.tgz#903a6ea3eb5cbf4c7ba7fa73cc43fc39ab7e4a70"
@@ -9568,6 +9576,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
 ignore@^5.1.4:
   version "5.1.8"


### PR DESCRIPTION
### Benefits

- To disallow unlimited disabling.
- To disallow unused disabling.
- To disallow non-effect enabling.
- To require rule IDs for disabling and enabling.

### Reference

https://github.com/mysticatea/eslint-plugin-eslint-comments

### Unused rules?

I found that we disabled some rules at top in most of files:

- `react/display-name`
- `no-redeclare`
- `react/jsx-no-target-blank`

If we don't want that rule, just disable it in `.eslint.common.js`. Otherwise, we should use `eslint-disable-next-line` instead of disabling the rule for the whole file.

I'm using `/* eslint rule-name: off */` instead of `/* eslint-disable rule-name */` in the PR. We could file another PR if we want to drop some rules or change them to `eslint-disable-next-line`.