### PR TITLE
chore(library): upgrade app-slide to 0.0.19

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -9,7 +9,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.11",
-    "@netless/app-slide": "^0.0.18",
+    "@netless/app-slide": "^0.0.19",
     "@netless/combine-player": "^1.1.4",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/fetch-middleware": "^1.0.7",
@@ -46,7 +46,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.2"
+    "white-web-sdk": "2.15.4"
   },
   "devDependencies": {
     "@netless/eslint-plugin": "1.1.2",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -39,7 +39,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.11",
-    "@netless/app-slide": "^0.0.18",
+    "@netless/app-slide": "^0.0.19",
     "@netless/combine-player": "^1.1.6",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/player-controller": "^0.0.9",
@@ -77,7 +77,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.2"
+    "white-web-sdk": "2.15.4"
   },
   "scripts": {
     "postinstall": "esbuild-dev ./scripts/post-install.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,10 @@
   resolved "https://registry.npmjs.org/@netless/app-monaco/-/app-monaco-0.1.11.tgz#f5fc1bc66dfb1ba0fa561483e7974d3771665138"
   integrity sha512-PwQDGHycri2gYCIF/SykokqjSyP/z8SShET2bmQd2UaVyMX11W2i5iAK4gntq22Cp5NW6JHawrTNbpfpoDMwMg==
 
-"@netless/app-slide@^0.0.18":
-  version "0.0.18"
-  resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.0.18.tgz#de22784af50c2bfe85683320e79293d9b7a49723"
-  integrity sha512-qJuHJsol60iITWk5gbD08CZdawsa/xtz7vSZrvzrxISaFjj1ggVcrbDmaFkcW7PvTs0/86w30jL8K+sMcYDrqQ==
+"@netless/app-slide@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.0.19.tgz#619ad6e476ca10ca5a002577ce8319779b9b006c"
+  integrity sha512-4fP+Ta+pqHPwzvOvjoLx1uN5dwwNyQD90o/a4Hig8ZYmlCsp2uJIqeoDvmN0jKvmgP3vjvc5ibgOcmKnYFWSrA==
 
 "@netless/canvas-polyfill@^0.0.4":
   version "0.0.4"
@@ -17261,10 +17261,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.15.2:
-  version "2.15.2"
-  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.15.2.tgz#8ea8b21742031d8f842301fbeef7746d1222aecd"
-  integrity sha512-jRQJJZE9hiiuxAqOaSo2h7mlan/xP0N3Peh4CVMFcP+0cy1pe26Qx1gSanR3rto5pqrGhdNuWSBnlCN2wKjeww==
+white-web-sdk@2.15.4:
+  version "2.15.4"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.15.4.tgz#d62a4d1e6f5245ded290f9ac5ce3236bba871bcf"
+  integrity sha512-AetBhpmHed3zF1hRu9UDmIwfYrW2R7N8DxSwvSsGKapCtH0gvEFsfxa/O2z+G+bWdqcpLSUiDNCXK/mXc81vfg==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"


### PR DESCRIPTION
- fixed animation of switching between pages
- requires white-web-sdk@2.15.4 to work
