### PR TITLE
chore(library): upgrade app-slide to 0.0.32

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -9,7 +9,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.11",
-    "@netless/app-slide": "^0.0.30",
+    "@netless/app-slide": "^0.0.32",
     "@netless/combine-player": "^1.1.4",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/fetch-middleware": "^1.0.7",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -40,7 +40,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.11",
-    "@netless/app-slide": "^0.0.30",
+    "@netless/app-slide": "^0.0.32",
     "@netless/combine-player": "^1.1.6",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/player-controller": "^0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,10 @@
   resolved "https://registry.npmjs.org/@netless/app-monaco/-/app-monaco-0.1.11.tgz#f5fc1bc66dfb1ba0fa561483e7974d3771665138"
   integrity sha512-PwQDGHycri2gYCIF/SykokqjSyP/z8SShET2bmQd2UaVyMX11W2i5iAK4gntq22Cp5NW6JHawrTNbpfpoDMwMg==
 
-"@netless/app-slide@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.0.30.tgz#17caaafd50a2417298b213e96689bb01b97288b4"
-  integrity sha512-X1baxa7LgcWj5vr6Ws5aLSfr7/z/asQKIl7crpAjQVhw1z3qCcf6OPgYG2vQjbwhE+GaLOoK/kF0yy0K1i4TrQ==
+"@netless/app-slide@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.0.32.tgz#336c34e48aec2b4125a2e18edfff26d8b7c66a75"
+  integrity sha512-7Z3Jh+GuaSY+8XnjX36+W9o1sPFt+kddRuELTUA0yWR16QdfPjTyUCBHLwNiWr39U0GAg1KdRRjCkpxiCviTaA==
 
 "@netless/canvas-polyfill@^0.0.4":
   version "0.0.4"


### PR DESCRIPTION
- fix: crash with video without url
- fix: not showing underline of white spaces
- fix: gif speed too fast
- fix: incorrect page number on some pages
