### PR TITLE
chore(library): upgrade white-web-sdk@2.15.8 & window-manager@0.3.8-canary.2

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -17,7 +17,7 @@
     "@netless/redo-undo": "^0.0.5",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.3.8-canary.1",
+    "@netless/window-manager": "^0.3.8-canary.2",
     "@videojs/vhs-utils": "^2.3.0",
     "agora-rtm-sdk": "^1.4.3",
     "antd": "^4.15.4",
@@ -46,7 +46,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.4"
+    "white-web-sdk": "2.15.8"
   },
   "devDependencies": {
     "@netless/eslint-plugin": "1.1.2",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -47,7 +47,7 @@
     "@netless/redo-undo": "^0.0.5",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.3.8-canary.1",
+    "@netless/window-manager": "^0.3.8-canary.2",
     "@videojs/vhs-utils": "^2.3.0",
     "@zip.js/zip.js": "^2.3.7",
     "agora-rtc-sdk-ng": "^4.5.0",
@@ -78,7 +78,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.4"
+    "white-web-sdk": "2.15.8"
   },
   "scripts": {
     "postinstall": "esbuild-dev ./scripts/post-install.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,10 +1966,10 @@
   resolved "https://registry.yarnpkg.com/@netless/video-js-plugin/-/video-js-plugin-0.3.7.tgz#6c1f174f20e8a93634e1770e7e535c1302bdf22b"
   integrity sha512-UG1t9464w1bZT9kzdhxj/K7R6jqI9sqYfqfUQJ2w9JRWsNibL6O16OC81iwBJT6nkGXEVN7z2pqHvNg1OhKppw==
 
-"@netless/window-manager@^0.3.8-canary.1":
-  version "0.3.8-canary.1"
-  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.3.8-canary.1.tgz#de9126c3f3d6be9e9d285f3adb795c4978bac851"
-  integrity sha512-tEGwSn5bwZrltRnZdGkhd7jTg9ZPS5Bd5wiOUAltrxt/ZHK4PTliASAhT9gOLm+mJC6wB3e8nmKnMNtQY9gKlw==
+"@netless/window-manager@^0.3.8-canary.2":
+  version "0.3.8-canary.2"
+  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.3.8-canary.2.tgz#e752c79d83145d18b495612cd9b0abbedeaec2c0"
+  integrity sha512-unSfOtV49cpCb1e3D+S0BeUF3XvW50s/qFYTekS9CTbDrXb1lieO1nKVQ1WZ/nqdX45Wjj+OZZGFPbPEcJziKA==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/app-docs-viewer" "^0.1.21"
@@ -17248,10 +17248,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.15.4:
-  version "2.15.4"
-  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.15.4.tgz#d62a4d1e6f5245ded290f9ac5ce3236bba871bcf"
-  integrity sha512-AetBhpmHed3zF1hRu9UDmIwfYrW2R7N8DxSwvSsGKapCtH0gvEFsfxa/O2z+G+bWdqcpLSUiDNCXK/mXc81vfg==
+white-web-sdk@2.15.8:
+  version "2.15.8"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.15.8.tgz#fb51bdb11b77c5ad4d23af7411fa623e1449ab87"
+  integrity sha512-dv3nFa4GRRmLQFK+jvt8wIQnO9h7WyJ68W/TPrkQbA4SrJwRtc0ZaXp4cMJbWbtHOgAy0QeZgVs2gPhd8NJYEw==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"


### PR DESCRIPTION

white-web-sdk:

- keep memberState state of local that when reloading or Disconnection not initialize the memberState state.
- keep state of  modify text style in float bar.

 window-manager:

- fix: when the window is minimum status, insert app not restore normal state.