### PR TITLE
refactor(web): revert login github open new window

### DIFF
--- a/web/flat-web/src/pages/LoginPage/githubLogin.ts
+++ b/web/flat-web/src/pages/LoginPage/githubLogin.ts
@@ -21,13 +21,7 @@ export const githubLogin: LoginExecutor = onSuccess => {
             errorTips(err);
         }
 
-        void window
-            .open(
-                getGithubURL(authUUID),
-                "LoginWithGithub",
-                "width=640,height=550,menubar=0,scrollbars=1,resizable=1,status=1,titlebar=0,toolbar=0,location=1",
-            )
-            ?.focus();
+        void window.open(getGithubURL(authUUID));
 
         const githubLoginProcessRequest = async (): Promise<void> => {
             try {


### PR DESCRIPTION
revert https://github.com/netless-io/flat/pull/1157

Because it did not meet expectations, wait for the zoning (China and foreign split to operate) before doing.

Now that the server is in Hangzhou, China, a new window would result in more white screen time and a poorer user experience.