### PR TITLE
fix(web): prevent duplicate `network error`

### DIFF
--- a/desktop/renderer-app/src/components/Tips/ErrorTips.tsx
+++ b/desktop/renderer-app/src/components/Tips/ErrorTips.tsx
@@ -9,8 +9,12 @@ export const errorTips = (e: unknown): void => {
     }
 
     if (e instanceof ServerRequestError) {
-        void message.error(i18n.t(e.errorMessage));
+        void message.error({
+            content: i18n.t(e.errorMessage),
+            key: e.errorMessage,
+        });
     } else {
-        void message.error((e as Error).message);
+        const { message: content, message: key } = e as Error;
+        void message.error({ content, key });
     }
 };

--- a/web/flat-web/src/components/Tips/ErrorTips.tsx
+++ b/web/flat-web/src/components/Tips/ErrorTips.tsx
@@ -9,8 +9,8 @@ export const errorTips = (e: unknown): void => {
     }
 
     if (e instanceof ServerRequestError) {
-        void message.error(i18n.t(e.errorMessage));
+        void message.error({ content: i18n.t(e.errorMessage), key: i18n.t(e.errorMessage) });
     } else {
-        void message.error((e as Error).message);
+        void message.error({ content: (e as Error).message, key: (e as Error).message });
     }
 };

--- a/web/flat-web/src/components/Tips/ErrorTips.tsx
+++ b/web/flat-web/src/components/Tips/ErrorTips.tsx
@@ -9,8 +9,12 @@ export const errorTips = (e: unknown): void => {
     }
 
     if (e instanceof ServerRequestError) {
-        void message.error({ content: i18n.t(e.errorMessage), key: i18n.t(e.errorMessage) });
+        void message.error({
+            content: i18n.t(e.errorMessage),
+            key: e.errorMessage,
+        });
     } else {
-        void message.error({ content: (e as Error).message, key: (e as Error).message });
+        const { message: content, message: key } = e as Error;
+        void message.error({ content, key });
     }
 };


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #1174 

The `antd` message component allows messages to be identified by a key. This key enables the content of a specific message to be updated dynamically, but it also ensures that a duplicate message will not be created for the given key. 

Setting the key to be equal to the error message ensures that only one of each type of error message will show at any given time. (For example, only one error with the message "Network Error" will be present, but an error message with different message content _would_ show up, if it occurred in addition to the "Network Error" message.)

(Prior to my changes, when I turned off the wifi and switched between the indicated menu items, two network error messages would appear.)

![errormsg](https://user-images.githubusercontent.com/84106309/144869222-0db39a9a-7823-453f-b827-2e1c8332a3ad.gif)


