### PR TITLE
fix(desktop): mouse cannot be displayed during screen sharing

### DIFF
--- a/desktop/renderer-app/src/api-middleware/share-screen.ts
+++ b/desktop/renderer-app/src/api-middleware/share-screen.ts
@@ -28,7 +28,7 @@ export class RTCShareScreen {
             height: 0,
             bitrate: 500,
             frameRate: 5,
-            captureMouseCursor: false,
+            captureMouseCursor: true,
             windowFocus: false,
             excludeWindowList: [],
             excludeWindowCount: 0,


### PR DESCRIPTION
Fixed: #1198 