### PR TITLE
fix(web): local track error introduced by #1203

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -92,6 +92,7 @@ module.exports = {
         "zindex", // antd
         "geogebra", // @netless/app-geogebra
         "commitlintrc", // @commitlint/cli
+        "unpublish", // agora-rtc-sdk-ng
 
         // misc
         "npmrc",

--- a/web/flat-web/src/api-middleware/rtc/avatar.ts
+++ b/web/flat-web/src/api-middleware/rtc/avatar.ts
@@ -57,10 +57,8 @@ export class RtcAvatar extends EventEmitter {
         this.observeVolumeId = window.setInterval(this.checkVolume, 500);
     }
 
-    public async destroy(): Promise<void> {
+    public destroy(): void {
         clearInterval(this.observeVolumeId);
-        await this.setMic(false);
-        await this.setCamera(false);
         this.rtc.removeAvatar(this);
     }
 

--- a/web/flat-web/src/api-middleware/rtc/room.ts
+++ b/web/flat-web/src/api-middleware/rtc/room.ts
@@ -103,12 +103,13 @@ export class RtcRoom {
             setMicrophoneTrack();
             setCameraTrack();
             if (this.client.localTracks.length > 0) {
-                for (const track of this.client.localTracks) {
+                const tracks = this.client.localTracks;
+                console.log("[rtc] unpublish local tracks");
+                await this.client.unpublish(tracks);
+                for (const track of tracks) {
                     track.stop();
                     track.close();
                 }
-                console.log("[rtc] unpublish local tracks");
-                await this.client.unpublish(this.client.localTracks);
             }
             this.client.off("user-published", this.onUserPublished);
             this.client.off("user-unpublished", this.onUserUnpublished);


### PR DESCRIPTION
Caused by calling `setEnabled()` after `unpublish()`.

renderer-app uses another rtc sdk, does not need to fix.
