### PR TITLE
refactor(main-app): support one window type create multi window

### DIFF
--- a/desktop/main-app/src/bootup/init-ipc.ts
+++ b/desktop/main-app/src/bootup/init-ipc.ts
@@ -13,9 +13,9 @@ export default (): void => {
 
     const appActionSyncKeys = Object.keys(appActionSync) as Array<keyof ipc.AppActionSync>;
     appActionSyncKeys.forEach(k => {
-        ipcMain.handle(k, appActionSync[k]);
+        ipcMain.handle(k, (_event, args) => appActionSync[k](args));
     });
 
-    const mainWin = windowManager.window(constants.WindowsName.Main)!;
+    const mainWin = windowManager.customWindow(constants.WindowsName.Main).getWin()!;
     injectionWindowIPCAction(mainWin);
 };

--- a/desktop/main-app/src/utils/ipc-actions.ts
+++ b/desktop/main-app/src/utils/ipc-actions.ts
@@ -139,6 +139,15 @@ export const appActionSync: ipc.AppActionSync = {
 
         return beta.hasNewVersion ? beta : stable;
     },
+    "can-create-window": args => {
+        const customWindow = windowManager.customWindow(args.windowName);
+
+        // multi instance window type => true
+        // single instance window type + current no window => true
+        const result = customWindow.isMultiInstance || customWindow.isEmpty();
+
+        return Promise.resolve(result);
+    },
 };
 
 export const injectionWindowIPCAction = (customWindow: CustomWindow): void => {

--- a/desktop/main-app/src/window-manager/abstract.ts
+++ b/desktop/main-app/src/window-manager/abstract.ts
@@ -7,25 +7,38 @@ import {
     WindowOptions,
 } from "./default-options";
 
-export abstract class AbstractWindow {
-    public win: CustomWindow | null = null;
+export abstract class AbstractWindow<MULTI_INSTANCE extends boolean> {
+    public wins: CustomWindow[] = [];
 
     public abstract readonly name: constants.WindowsName;
     public abstract create(option: BrowserWindowConstructorOptions): CustomWindow;
 
-    public remove(): void {
-        if (!this.win) {
+    protected constructor(public isMultiInstance: MULTI_INSTANCE) {}
+
+    public remove(...ids: MULTI_INSTANCE extends true ? number[] : never[]): void {
+        if (this.isEmpty()) {
             return;
         }
 
-        if (this.win.window.isDestroyed()) {
-            this.win = null;
+        if (!this.isMultiInstance) {
+            AbstractWindow.closeWindow(this.wins[0]);
 
-            return;
+            this.wins = [];
+        } else {
+            if (ids.length === 0) {
+                this.wins.forEach(AbstractWindow.closeWindow);
+                this.wins = [];
+            } else {
+                this.wins = this.wins.filter(win => {
+                    if ((ids as number[]).includes(win.window.id)) {
+                        AbstractWindow.closeWindow(win);
+                        return false;
+                    }
+
+                    return true;
+                });
+            }
         }
-
-        this.win.options.disableClose = false;
-        this.win.window.close();
     }
 
     protected createWindow(
@@ -46,19 +59,55 @@ export abstract class AbstractWindow {
             ...windowOptions,
         };
 
-        this.win = {
+        const win = {
             options,
             window,
             didFinishLoad: options.isPortal ? Promise.resolve() : window.loadURL(options.url),
         };
 
-        windowOpenDevTools(this.win);
+        if (this.isMultiInstance) {
+            this.wins.push(win);
+        } else {
+            this.wins[0] = win;
+        }
 
-        windowHookClose(this.win);
+        windowOpenDevTools(win);
 
-        windowReadyToShow(this.win);
+        windowHookClose(win);
 
-        return this.win;
+        windowReadyToShow(win);
+
+        return win;
+    }
+
+    public getWin(...ids: MULTI_INSTANCE extends true ? [number] : never[]): CustomWindow | null;
+    public getWin(...ids: any[]): CustomWindow | null {
+        if (this.isEmpty()) {
+            return null;
+        }
+
+        if (this.isMultiInstance) {
+            const id = ids[0];
+            for (const win of this.wins) {
+                if (win.window.id === id) {
+                    return win;
+                }
+            }
+            return null;
+        }
+
+        return this.wins[0] || null;
+    }
+
+    public isEmpty(): boolean {
+        return this.wins.length === 0;
+    }
+
+    private static closeWindow(win: CustomWindow): void {
+        if (!win.window.isDestroyed()) {
+            win.options.disableClose = false;
+            win.window.close();
+        }
     }
 }
 
@@ -69,5 +118,16 @@ export type CustomWindow = {
 };
 
 export type AbstractWindows = {
-    [K in constants.WindowsName]: AbstractWindow;
+    [constants.WindowsName.Main]: AbstractWindow<false>;
+    [constants.WindowsName.ShareScreenTip]: AbstractWindow<false>;
 };
+
+// see: https://stackoverflow.com/questions/67114094/typescript-get-type-of-generic-class-parameter
+type GetClassParameterForAbstractWindow<T extends AbstractWindow<any>> = T extends AbstractWindow<
+    infer R
+>
+    ? R
+    : unknown;
+
+export type IsMultiInstance<NAME extends constants.WindowsName> =
+    GetClassParameterForAbstractWindow<AbstractWindows[NAME]>;

--- a/desktop/main-app/src/window-manager/abstract.ts
+++ b/desktop/main-app/src/window-manager/abstract.ts
@@ -22,23 +22,25 @@ export abstract class AbstractWindow<MULTI_INSTANCE extends boolean> {
 
         if (!this.isMultiInstance) {
             AbstractWindow.closeWindow(this.wins[0]);
-
             this.wins = [];
-        } else {
-            if (ids.length === 0) {
-                this.wins.forEach(AbstractWindow.closeWindow);
-                this.wins = [];
-            } else {
-                this.wins = this.wins.filter(win => {
-                    if ((ids as number[]).includes(win.window.id)) {
-                        AbstractWindow.closeWindow(win);
-                        return false;
-                    }
-
-                    return true;
-                });
-            }
+            return;
         }
+
+        if (ids.length === 0) {
+            this.wins.forEach(AbstractWindow.closeWindow);
+            this.wins = [];
+
+            return;
+        }
+
+        this.wins = this.wins.filter(win => {
+            if ((ids as number[]).includes(win.window.id)) {
+                AbstractWindow.closeWindow(win);
+                return false;
+            }
+
+            return true;
+        });
     }
 
     protected createWindow(

--- a/desktop/main-app/src/window-manager/window-main/index.ts
+++ b/desktop/main-app/src/window-manager/window-main/index.ts
@@ -6,12 +6,12 @@ import { ipcMain } from "electron";
 import { zip } from "rxjs";
 import { ignoreElements, mergeMap } from "rxjs/operators";
 
-export class WindowMain extends AbstractWindow {
+export class WindowMain extends AbstractWindow<false> {
     public readonly name = constants.WindowsName.Main;
     private readonly subject: RxSubject;
 
     public constructor() {
-        super();
+        super(false);
 
         this.subject = new RxSubject();
     }
@@ -46,7 +46,7 @@ export class WindowMain extends AbstractWindow {
 
     public async assertWindow(): Promise<CustomWindow> {
         return this.subject.mainWindowCreated.toPromise().then(() => {
-            return this.win!;
+            return this.wins[0]!;
         });
     }
 

--- a/desktop/main-app/src/window-manager/window-manager.ts
+++ b/desktop/main-app/src/window-manager/window-manager.ts
@@ -4,7 +4,7 @@ import { WindowStore } from "./window-store";
 import { CustomWindow, AbstractWindows } from "./abstract";
 
 export class WindowManager<
-    ABSTRACT_WINDOWS extends AbstractWindows = AbstractWindows,
+    ABSTRACT_WINDOWS extends AbstractWindows,
 > extends WindowStore<ABSTRACT_WINDOWS> {
     public constructor(wins: ABSTRACT_WINDOWS) {
         super(wins);
@@ -13,12 +13,12 @@ export class WindowManager<
     public create<NAME extends constants.WindowsName>(
         name: NAME,
         option?: BrowserWindowConstructorOptions,
-    ): NonNullable<ABSTRACT_WINDOWS[NAME]["win"]> {
+    ): CustomWindow {
         const customWindow = this.wins[name].create(option || {});
 
         this.interceptPortalNewWindow(customWindow);
 
-        return customWindow as NonNullable<ABSTRACT_WINDOWS[NAME]["win"]>;
+        return customWindow;
     }
 
     public remove(name: constants.WindowsName): void {

--- a/desktop/main-app/src/window-manager/window-portal/utils.ts
+++ b/desktop/main-app/src/window-manager/window-portal/utils.ts
@@ -3,7 +3,10 @@ import { windowManager } from "../index";
 import { constants } from "flat-types";
 
 export const getDisplayByMainWindow = (): Display => {
-    const mainBounds = windowManager.window(constants.WindowsName.Main)!.window.getBounds();
+    const mainBounds = windowManager
+        .customWindow(constants.WindowsName.Main)
+        .getWin()!
+        .window.getBounds();
 
     return screen.getDisplayNearestPoint({
         x: mainBounds.x,

--- a/desktop/main-app/src/window-manager/window-portal/window-share-screen-tip.ts
+++ b/desktop/main-app/src/window-manager/window-portal/window-share-screen-tip.ts
@@ -2,8 +2,12 @@ import { AbstractWindow, CustomWindow } from "../abstract";
 import { constants } from "flat-types";
 import { getDisplayByMainWindow, getXCenterPoint } from "./utils";
 
-export class WindowShareScreenTip extends AbstractWindow {
+export class WindowShareScreenTip extends AbstractWindow<false> {
     public readonly name = constants.WindowsName.ShareScreenTip;
+
+    public constructor() {
+        super(false);
+    }
 
     public create(options: Electron.BrowserWindowConstructorOptions): CustomWindow {
         const display = getDisplayByMainWindow();

--- a/desktop/main-app/src/window-manager/window-store.ts
+++ b/desktop/main-app/src/window-manager/window-store.ts
@@ -4,10 +4,6 @@ import { AbstractWindows } from "./abstract";
 export class WindowStore<CUSTOM_WINDOWS extends AbstractWindows> {
     public constructor(protected readonly wins: CUSTOM_WINDOWS) {}
 
-    public window<NAME extends constants.WindowsName>(name: NAME): CUSTOM_WINDOWS[NAME]["win"] {
-        return this.wins[name].win;
-    }
-
     public customWindow<NAME extends constants.WindowsName>(name: NAME): CUSTOM_WINDOWS[NAME] {
         return this.wins[name];
     }

--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreenTip/index.tsx
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreenTip/index.tsx
@@ -10,6 +10,7 @@ import dragSVG from "../../../assets/image/drag.svg";
 import { Button } from "antd";
 import { ShareScreenStore } from "../../../stores/share-screen-store";
 import { useTranslation } from "react-i18next";
+import { useSafePromise } from "../../../utils/hooks/lifecycle";
 
 interface ShareScreenTipProps {
     shareScreenStore: ShareScreenStore;
@@ -18,21 +19,22 @@ interface ShareScreenTipProps {
 export const ShareScreenTip = observer<ShareScreenTipProps>(function ShareScreenTip({
     shareScreenStore,
 }) {
+    const sp = useSafePromise();
     const { t } = useTranslation();
     const [windowInstance, setWindowInstance] = useState<null | Window>(null);
     const [containerEl] = useState(() => document.createElement("div"));
 
     useEffect(() => {
-        const instance = portalWindowManager.createShareScreenTipPortalWindow(containerEl);
-
-        setWindowInstance(instance);
+        sp(portalWindowManager.createShareScreenTipPortalWindow(containerEl))
+            .then(setWindowInstance)
+            .catch(console.error);
 
         return () => {
             ipcAsyncByApp("force-close-window", {
                 windowName: constants.WindowsName.ShareScreenTip,
             });
         };
-    }, [containerEl, t]);
+    }, [containerEl, sp, t]);
 
     useEffect(() => {
         if (windowInstance) {

--- a/packages/flat-types/src/ipc/index.ts
+++ b/packages/flat-types/src/ipc/index.ts
@@ -33,6 +33,7 @@ export type AppActionSync = {
     "get-runtime": () => Promise<RuntimeType>;
     "get-open-at-login": () => Promise<boolean>;
     "get-update-info": () => Promise<UpdateCheckInfo>;
+    "can-create-window": (args: { windowName: WindowsName }) => Promise<boolean>;
 };
 
 export interface EmitEvents {


### PR DESCRIPTION
So far we have two WindowName:
1. `WindowsName.Main` => flat app main window
2. `WindowsName.ShareScreenTip` => share screen tip window
     * <img width="309" alt="image" src="https://user-images.githubusercontent.com/8198408/147084719-a15d8d1a-2295-4342-93f0-cc5f51204ae5.png">

In the previous multi-window architecture, a WindowName (window type) could only create one `BrowserWindow`. they had a one-to-one relationship. (one WindowName corresponds to BrowserWindow)

But we recently had a new requirement: when previewing files in the cloud storage list, we wanted a new window. And there is no limit to the number.

So we need to modify the current multi-window code architecture to support one WindowName(window type) for multiple BrowserWindow

One thing to note about this current PR is that when the rendering process creates a new window, it needs to send an ipc message to the master process to let the master process tell the rendering process if it can create the window.
**This is a defensive code**