### PR TITLE
chore(library): upgrade window-manager to 0.3.16-canary.2

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -17,7 +17,7 @@
     "@netless/redo-undo": "^0.0.5",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.3.16-canary.1",
+    "@netless/window-manager": "^0.3.16-canary.2",
     "@videojs/vhs-utils": "^2.3.0",
     "agora-rtm-sdk": "^1.4.3",
     "antd": "^4.15.4",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -47,7 +47,7 @@
     "@netless/redo-undo": "^0.0.5",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.3.16-canary.1",
+    "@netless/window-manager": "^0.3.16-canary.2",
     "@videojs/vhs-utils": "^2.3.0",
     "@zip.js/zip.js": "^2.3.7",
     "agora-rtc-sdk-ng": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,10 +1966,10 @@
   resolved "https://registry.yarnpkg.com/@netless/video-js-plugin/-/video-js-plugin-0.3.7.tgz#6c1f174f20e8a93634e1770e7e535c1302bdf22b"
   integrity sha512-UG1t9464w1bZT9kzdhxj/K7R6jqI9sqYfqfUQJ2w9JRWsNibL6O16OC81iwBJT6nkGXEVN7z2pqHvNg1OhKppw==
 
-"@netless/window-manager@^0.3.16-canary.1":
-  version "0.3.16-canary.1"
-  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.3.16-canary.1.tgz#811f3da86e5dd76480a2e6f87f8d378c6c1ed552"
-  integrity sha512-z7IIkGwrj5SpkRG//RR0mBITrENPu0NRaHg9uV0sGBiqNgLf/kMpqf0MQSJv6fYdq8t2gxY5gG/9h0J646R9aw==
+"@netless/window-manager@^0.3.16-canary.2":
+  version "0.3.16-canary.2"
+  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.3.16-canary.2.tgz#1cd9a17ffd502bf2329f90901a76cb0fb9ba2551"
+  integrity sha512-LdbCEr//9mXaHEAN8C64ES6MSb9YElDu2LMg0avZdZEXk9+Ue/elD573J/0pw/FEl9AGq2pEa1sHzu/md2M+eA==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/app-docs-viewer" "0.1.24"


### PR DESCRIPTION
- fix: room camera data is empty that setting fail when the permission to writeable user first joined