### PR TITLE
refactor(desktop): improve accuracy of ipc messages sent and received

### DIFF
--- a/desktop/main-app/src/utils/ipc-actions.ts
+++ b/desktop/main-app/src/utils/ipc-actions.ts
@@ -158,9 +158,16 @@ export const injectionWindowIPCAction = (customWindow: CustomWindow): void => {
             args: {
                 actions: keyof ipc.WindowActionAsync;
                 args: any;
+                browserWindowID: number;
             },
         ) => {
-            windowActionAsync(customWindow)[args.actions](args.args);
+            const realCustomWindow = windowManager
+                .windowType(customWindow.options.name)
+                .getWin(args.browserWindowID);
+
+            if (realCustomWindow) {
+                windowActionAsync(customWindow)[args.actions](args.args);
+            }
         },
     );
 };

--- a/desktop/main-app/src/window-manager/window-manager.ts
+++ b/desktop/main-app/src/window-manager/window-manager.ts
@@ -42,8 +42,13 @@ export class WindowManager<
                     frameName.substring(constants.Portal.length),
                 );
 
-                // @ts-ignore
-                event.newGuest = this.create(customOptions.name, options).window;
+                const window = this.create(customOptions.name, options).window;
+
+                event.newGuest = window;
+
+                window.webContents
+                    .executeJavaScript(`window.browserWindowID = ${window.id}`)
+                    .catch(console.error);
             },
         );
     }

--- a/desktop/renderer-app/src/utils/ipc.ts
+++ b/desktop/renderer-app/src/utils/ipc.ts
@@ -12,6 +12,7 @@ export const ipcAsyncByMainWindow = <
     ipcRenderer.send(constants.WindowsName.Main, {
         actions: action,
         args,
+        browserWindowID: NaN,
     });
 };
 
@@ -25,6 +26,7 @@ export const ipcAsyncByShareScreenTipWindow = <
     ipcRenderer.send(constants.WindowsName.ShareScreenTip, {
         actions: action,
         args,
+        browserWindowID: NaN,
     });
 };
 

--- a/desktop/renderer-app/typings/global.d.ts
+++ b/desktop/renderer-app/typings/global.d.ts
@@ -37,3 +37,7 @@ declare namespace NodeJS {
 interface Window {
     rtcEngine: any;
 }
+
+interface PortalWindow extends Window {
+    browserWindowID: string;
+}


### PR DESCRIPTION
add `window.browserWindowID` to any `BrowserWindow.webContexts`
send ipc message must carry browserWindowID in render process
single window type(e.g. _Main_ and _ShareScreenTip_) can pass on `NaN`