### PR TITLE
refactor(whiteboard): adjust the way to shrink image on insert

### DIFF
--- a/desktop/renderer-app/src/stores/whiteboard-store.ts
+++ b/desktop/renderer-app/src/stores/whiteboard-store.ts
@@ -514,7 +514,6 @@ export class WhiteboardStore {
 
         // 1. shrink the image a little to fit the screen
         const maxWidth = window.innerWidth * 0.8;
-        // const maxHeight = window.innerHeight * 0.8;
 
         let width: number;
         let height: number;

--- a/desktop/renderer-app/src/stores/whiteboard-store.ts
+++ b/desktop/renderer-app/src/stores/whiteboard-store.ts
@@ -512,9 +512,9 @@ export class WhiteboardStore {
             return;
         }
 
-        // shrink the image a little to fit the screen
+        // 1. shrink the image a little to fit the screen
         const maxWidth = window.innerWidth * 0.8;
-        const maxHeight = window.innerHeight * 0.8;
+        // const maxHeight = window.innerHeight * 0.8;
 
         let width: number;
         let height: number;
@@ -532,19 +532,33 @@ export class WhiteboardStore {
         }
 
         let scale = 1;
-        if (width > maxWidth || height > maxHeight) {
-            scale = Math.min(maxWidth / width, maxHeight / height);
+        if (width > maxWidth) {
+            scale = maxWidth / width;
         }
 
         const uuid = v4uuid();
+        const { centerX, centerY } = room.state.cameraState;
+        width *= scale;
+        height *= scale;
         room.insertImage({
             uuid,
-            ...room.state.cameraState,
-            width: Math.floor(width * scale),
-            height: Math.floor(height * scale),
+            centerX,
+            centerY,
+            width: Math.floor(width),
+            height: Math.floor(height),
             locked: false,
         });
         room.completeImageUpload(uuid, file.fileURL);
+
+        // 2. move camera to fit image height
+        width /= 0.8;
+        height /= 0.8;
+        room.moveCameraToContain({
+            originX: centerX - width / 2,
+            originY: centerY - height / 2,
+            width: width,
+            height: height,
+        });
     };
 
     public insertMediaFile = async (file: CloudStorageFile): Promise<void> => {

--- a/web/flat-web/src/stores/whiteboard-store.ts
+++ b/web/flat-web/src/stores/whiteboard-store.ts
@@ -522,7 +522,6 @@ export class WhiteboardStore {
 
         // 1. shrink the image a little to fit the screen
         const maxWidth = window.innerWidth * 0.8;
-        // const maxHeight = window.innerHeight * 0.8;
 
         let width: number;
         let height: number;

--- a/web/flat-web/src/stores/whiteboard-store.ts
+++ b/web/flat-web/src/stores/whiteboard-store.ts
@@ -520,9 +520,9 @@ export class WhiteboardStore {
             return;
         }
 
-        // shrink the image a little to fit the screen
+        // 1. shrink the image a little to fit the screen
         const maxWidth = window.innerWidth * 0.8;
-        const maxHeight = window.innerHeight * 0.8;
+        // const maxHeight = window.innerHeight * 0.8;
 
         let width: number;
         let height: number;
@@ -540,19 +540,33 @@ export class WhiteboardStore {
         }
 
         let scale = 1;
-        if (width > maxWidth || height > maxHeight) {
-            scale = Math.min(maxWidth / width, maxHeight / height);
+        if (width > maxWidth) {
+            scale = maxWidth / width;
         }
 
         const uuid = v4uuid();
+        const { centerX, centerY } = room.state.cameraState;
+        width *= scale;
+        height *= scale;
         room.insertImage({
             uuid,
-            ...room.state.cameraState,
-            width: Math.floor(width * scale),
-            height: Math.floor(height * scale),
+            centerX,
+            centerY,
+            width: Math.floor(width),
+            height: Math.floor(height),
             locked: false,
         });
         room.completeImageUpload(uuid, file.fileURL);
+
+        // 2. move camera to fit image height
+        width /= 0.8;
+        height /= 0.8;
+        room.moveCameraToContain({
+            originX: centerX - width / 2,
+            originY: centerY - height / 2,
+            width: width,
+            height: height,
+        });
     };
 
     public insertMediaFile = async (file: CloudStorageFile): Promise<void> => {


### PR DESCRIPTION
**Old behavior:**
Shrink the image size (both width and height) to the screen size.

**New behavior:**
First shrink the image width to the screen width,\
then move the whiteboard camera to contain the whole image.

This way, if the image is very big and contains text (like a paper captured from the camera of phone), the pencil's width won't be too thick when zoomed in.