### PR TITLE
fix(desktop): Apple M1 open and build failed on development

### DIFF
--- a/desktop/main-app/package.json
+++ b/desktop/main-app/package.json
@@ -40,7 +40,7 @@
     "cross-env": "^7.0.3",
     "dotenv-flow": "^3.2.0",
     "dotenv-flow-webpack": "^1.1.0",
-    "electron": "11.3.0",
+    "electron": "12.0.15",
     "electron-builder": "^22.10.5",
     "electron-devtools-vendor": "^1.0.2",
     "electron-notarize": "^1.0.0",

--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -72,7 +72,7 @@
     "css-loader": "^5.2.4",
     "dotenv-flow": "^3.2.0",
     "dotenv-flow-webpack": "^1.1.0",
-    "electron": "11.3.0",
+    "electron": "12.0.15",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",

--- a/scripts/init-agora-configure/agora-electron-options.js
+++ b/scripts/init-agora-configure/agora-electron-options.js
@@ -2,7 +2,7 @@
 const agoraSdkOptions = {
     arch: process.platform === "win32" ? "ia32" : "x64",
     platform: process.platform === "win32" ? "win32" : "darwin",
-    electron_version: "11.0.0",
+    electron_version: "12.0.0",
     msvs_version: "2017",
     silent: false,
     debug: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,15 +3263,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
-"@types/node@^12.0.12":
-  version "12.20.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.19.tgz#538e61fc220f77ae4a4663c3d8c3cb391365c209"
-  integrity sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==
-
 "@types/node@^14.0.10":
   version "14.17.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.9.tgz#b97c057e6138adb7b720df2bd0264b03c9f504fd"
   integrity sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==
+
+"@types/node@^14.6.2":
+  version "14.18.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.3.tgz#b3682cfd9d5542b025df13233d073cb4347f63f3"
+  integrity sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==
 
 "@types/node@^15.0.3":
   version "15.14.7"
@@ -7214,13 +7214,13 @@ electron-updater@^4.3.8:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.3.0.tgz#87e8528fd23ae53b0eeb3a738f1fe0a3ad27c2db"
-  integrity sha512-MhdS0gok3wZBTscLBbYrOhLaQybCSAfkupazbK1dMP5c+84eVMxJE/QGohiWQkzs0tVFIJsAHyN19YKPbelNrQ==
+electron@12.0.15:
+  version "12.0.15"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-12.0.15.tgz#d1a50f2037bdf163c5a3df6fe9beabb0b6bb4d37"
+  integrity sha512-JyhYJkj4BD0YPii8gTcYmTTBbHPomCtEKt9/OfoezAhc1scTDP+yZkAfBJrlgVFh0IYmyuesdQzuNEohSdz6Wg==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 element-resize-detector@^1.2.2:


### PR DESCRIPTION
error desc on Apple M1:
```
<--- Last few GCs --->

[99467:0x7100000000]      808 ms: Scavenge 26.0 (35.5) -> 23.4 (39.2) MB, 2.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure
[99467:0x7100000000]      986 ms: Mark-sweep 29.9 (41.8) -> 23.0 (43.2) MB, 16.5 / 0.0 ms  (+ 0.0 ms in 0 steps since start of marking, biggest step 0.0 ms, walltime since start of marking 20 ms) (average mu = 1.000, current mu = 1.000) external finalize

<--- JS stacktrace --->
```

The solution to this problem is as simple as upgrading electron to version 12.0.15

see:
 * https://github.com/electron/electron/pull/26650
 * https://github.com/electron/electron/issues/27497
 * https://github.com/microsoft/vscode/issues/106770