### PR TITLE
chore(library): upgrade app-slide to 0.0.55

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -9,7 +9,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.12",
-    "@netless/app-slide": "0.0.54",
+    "@netless/app-slide": "0.0.55",
     "@netless/combine-player": "^1.1.4",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/fetch-middleware": "^1.0.7",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -40,7 +40,7 @@
     "@netless/app-geogebra": "^0.0.2",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.12",
-    "@netless/app-slide": "0.0.54",
+    "@netless/app-slide": "0.0.55",
     "@netless/combine-player": "^1.1.6",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/player-controller": "^0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,11 +1111,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/standalone@7.13.9":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.13.9.tgz#38e78673e19f5077f4b294ad346780634e59e276"
-  integrity sha512-9ZpIl8rXXQqm5OdsQVhlBSPttwabiHGPGrl5N2bIxB9XS2NJW+1oiPFgMMNd+57C/xVwsEwD2mzv0KValOwlQA==
-
 "@babel/standalone@7.14.1":
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.14.1.tgz#2c5f6908f03108583eea75bdcc94eb29e720fbac"
@@ -1900,10 +1895,10 @@
   resolved "https://registry.npmjs.org/@netless/app-monaco/-/app-monaco-0.1.12.tgz#bd289d088cd9f6db664220becc80a2db02313c2b"
   integrity sha512-f8LLS5jVcBXn5Ua1HfWNHUq7wa/yax81+XTfjXJ8B2ztOGTHB1uHDveD/hjcWCTCEeZP/sv8c8HTXwqb0fLUcg==
 
-"@netless/app-slide@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@netless/app-slide/-/app-slide-0.0.54.tgz#d775bf43d7e04fc1b808e8145d54d127475a2909"
-  integrity sha512-SsaZGnkCeYB3meQaM3K8o9Z3NHRt0bFTM+aLdbftmc+fPJYFT/a/v1gWRib9Wjaln7cCKjQWoA7I8crK8SNvSg==
+"@netless/app-slide@0.0.55":
+  version "0.0.55"
+  resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.0.55.tgz#1b6b725234d336921f10074924d090116ad7c09d"
+  integrity sha512-HhPZ+WdtxnQLZFoM8wfBwLCXkL0gJV3B1jelTzecEnWnyCbEhngVb9BIIHnRfn31wq82pudeMsZvs9Tu1PfLiQ==
 
 "@netless/canvas-polyfill@^0.0.4":
   version "0.0.4"


### PR DESCRIPTION
- enable click on the page to next step
- fix crash on closing the app when playing animation
- fix missing animations with height: 0
- fix incorrect animation colors
- support `xshear` and `yshear`
