### PR TITLE
chore(eslint): fix ESLint editor settings for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,15 @@
 {
   "editor.formatOnSave": true,
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "i18n-ally.localesPaths": ["./packages/flat-i18n/locales/"],
   "i18n-ally.enabledFrameworks": ["react", "i18next"],
   "i18n-ally.keystyle": "nested",
   "i18n-ally.sourceLanguage": "zh-CN",
   "i18n-ally.displayLanguage": "zh-CN",
+  "eslint.enable": true,
   "eslint.workingDirectories": [
     {
       "directory": "desktop/main-app",


### PR DESCRIPTION
We should explicitly list all ESLint related configurations in settings file.