### PR TITLE
feat(web): enable acoustic echo cancellation and noise suppression

### DIFF
--- a/web/flat-web/src/api-middleware/rtc/device-test.ts
+++ b/web/flat-web/src/api-middleware/rtc/device-test.ts
@@ -82,6 +82,10 @@ export class DeviceTest {
         } else {
             this.microphoneAudioTrack = await AgoraRTC.createMicrophoneAudioTrack({
                 microphoneId: deviceId,
+                // AEC: acoustic echo cancellation
+                AEC: true,
+                // ANS: automatic noise suppression
+                ANS: true,
             });
         }
     }

--- a/web/flat-web/src/api-middleware/rtc/room.ts
+++ b/web/flat-web/src/api-middleware/rtc/room.ts
@@ -136,6 +136,10 @@ export class RtcRoom {
             await this.joined;
             this._localAudioTrack = await AgoraRTC.createMicrophoneAudioTrack({
                 microphoneId: configStore.microphoneId,
+                // AEC: acoustic echo cancellation
+                AEC: true,
+                // ANS: automatic noise suppression
+                ANS: true,
             });
             setMicrophoneTrack(this._localAudioTrack as IMicrophoneAudioTrack);
             this._localAudioTrack.once("track-ended", () => {


### PR DESCRIPTION
AEC: acoustic echo cancellation
ANS: automatic noise suppression

The electron platform using `agora-electron-sdk` will enable the below option default, so we just need to enable AEC and ANS with `agora-rtc-sdk-ng` for browser user.