### PR TITLE
chore(eslint): optimize imports

### DIFF
--- a/.eslint.common.js
+++ b/.eslint.common.js
@@ -12,9 +12,9 @@ const eslintCommon = {
             "plugin:@typescript-eslint/recommended",
             "plugin:@typescript-eslint/recommended-requiring-type-checking",
             "plugin:prettier/recommended",
-            "plugin:eslint-comments/recommended"
+            "plugin:eslint-comments/recommended",
         ],
-        plugins: ["@netless", "prettier", "@typescript-eslint", "eslint-comments"],
+        plugins: ["@netless", "prettier", "@typescript-eslint", "import", "eslint-comments"],
         rules: {
             "array-callback-return": "warn",
             "default-case": "off",
@@ -125,6 +125,48 @@ const eslintCommon = {
             "no-whitespace-before-property": "warn",
             "require-yield": "warn",
             "rest-spread-spacing": ["warn", "never"],
+            "sort-imports": [
+                "error",
+                {
+                    ignoreCase: false,
+                    ignoreDeclarationSort: true,
+                    ignoreMemberSort: false,
+                    memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+                    allowSeparatedGroups: false,
+                },
+            ],
+            "import/no-duplicates": "error",
+            "import/order": [
+                "error",
+                {
+                    groups: ["builtin", "external", "parent", "sibling", "index"],
+                    pathGroups: [
+                        {
+                            pattern: "react",
+                            group: "builtin",
+                            position: "before",
+                        },
+                        {
+                            pattern: "antd/es/*/style/index",
+                            group: "index",
+                            position: "after",
+                        },
+                        {
+                            pattern: "*.+(css|less|mp3)",
+                            patternOptions: { matchBase: true },
+                            group: "index",
+                            position: "after",
+                        },
+                    ],
+                    alphabetize: {
+                        order: "asc",
+                        caseInsensitive: true,
+                    },
+                    pathGroupsExcludedImportTypes: ["react"],
+                    warnOnUnassignedImports: true,
+                    "newlines-between": "never",
+                },
+            ],
             strict: ["warn", "never"],
             "unicode-bom": ["warn", "never"],
             "valid-typeof": "warn",
@@ -159,6 +201,12 @@ const eslintCommon = {
             ],
             "@typescript-eslint/no-empty-interface": "off",
             "@typescript-eslint/consistent-type-assertions": "error",
+            "@typescript-eslint/consistent-type-imports": [
+                "error",
+                {
+                    prefer: "no-type-imports",
+                },
+            ],
             "@typescript-eslint/explicit-member-accessibility": [
                 "error",
                 {
@@ -194,6 +242,13 @@ const eslintCommon = {
                     argsIgnorePattern: "^_",
                 },
             ],
+        },
+        settings: {
+            "import/resolver": {
+                node: {
+                    extensions: [".js", ".mjs", ".jsx", ".json", ".wasm", ".ts", "tsx"],
+                },
+            },
         },
         overrides: [
             {
@@ -239,8 +294,8 @@ const eslintCommon = {
                     ignore: [],
                 },
             ],
-            'react/jsx-sort-props': [
-                'error',
+            "react/jsx-sort-props": [
+                "error",
                 {
                     callbacksLast: true,
                     shorthandFirst: true,

--- a/desktop/main-app/package.json
+++ b/desktop/main-app/package.json
@@ -47,6 +47,7 @@
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-webpack-plugin": "^3.0.1",
     "file-loader": "^6.2.0",

--- a/desktop/main-app/src/bootup/init-app-ipc.ts
+++ b/desktop/main-app/src/bootup/init-app-ipc.ts
@@ -1,6 +1,6 @@
-import { appActionAsync, appActionSync } from "../utils/ipc-actions";
-import { ipc } from "flat-types";
 import { ipcMain } from "electron";
+import { ipc } from "flat-types";
+import { appActionAsync, appActionSync } from "../utils/ipc-actions";
 
 export default (): void => {
     const appActionAsyncKeys = Object.keys(appActionAsync) as Array<keyof ipc.AppActionAsync>;

--- a/desktop/main-app/src/bootup/init-menus.ts
+++ b/desktop/main-app/src/bootup/init-menus.ts
@@ -1,4 +1,4 @@
-import { app, Menu, MenuItemConstructorOptions } from "electron";
+import { Menu, MenuItemConstructorOptions, app } from "electron";
 import runtime from "../utils/runtime";
 
 export default (): void => {

--- a/desktop/main-app/src/bootup/init-url-protocol.ts
+++ b/desktop/main-app/src/bootup/init-url-protocol.ts
@@ -1,8 +1,8 @@
-import runtime from "../utils/runtime";
 import { app } from "electron";
-import closeAPP from "../utils/close-app";
-import { windowManager } from "../window-manager";
 import { constants } from "flat-types";
+import closeAPP from "../utils/close-app";
+import runtime from "../utils/runtime";
+import { windowManager } from "../window-manager";
 import { CustomWindow } from "../window-manager/abstract";
 
 export default async (): Promise<void> => {

--- a/desktop/main-app/src/bootup/init-webRequest.ts
+++ b/desktop/main-app/src/bootup/init-webRequest.ts
@@ -1,6 +1,6 @@
+import path from "path";
 import { protocol, session } from "electron";
 import fs from "fs-extra";
-import path from "path";
 import runtime from "../utils/runtime";
 
 export default (): void => {

--- a/desktop/main-app/src/bootup/init-window.ts
+++ b/desktop/main-app/src/bootup/init-window.ts
@@ -1,6 +1,6 @@
 import { app } from "electron";
-import { windowManager } from "../window-manager";
 import { constants } from "flat-types";
+import { windowManager } from "../window-manager";
 
 export default (): void => {
     app.allowRendererProcessReuse = false;

--- a/desktop/main-app/src/index.ts
+++ b/desktop/main-app/src/index.ts
@@ -1,12 +1,12 @@
-import bootstrap from "./utils/bootup-flow";
-import initEnv from "./bootup/init-env";
-import initWindow from "./bootup/init-window";
-import initWebRequest from "./bootup/init-webRequest";
-import initMenus from "./bootup/init-menus";
 import intAppIPC from "./bootup/init-app-ipc";
 import initAppListen from "./bootup/init-app-listener";
+import initEnv from "./bootup/init-env";
+import initMenus from "./bootup/init-menus";
 import initOtherListeners from "./bootup/init-other";
 import initURLProtocol from "./bootup/init-url-protocol";
+import initWebRequest from "./bootup/init-webRequest";
+import initWindow from "./bootup/init-window";
+import bootstrap from "./utils/bootup-flow";
 
 void bootstrap([
     initEnv,

--- a/desktop/main-app/src/preload.ts
+++ b/desktop/main-app/src/preload.ts
@@ -1,4 +1,4 @@
-import type AgoraRtcEngine from "agora-electron-sdk";
+import AgoraRtcSDK from "agora-electron-sdk";
 const { ipcRenderer } = require("electron");
 
 /**
@@ -15,9 +15,7 @@ ipcRenderer.once("inject-agora-electron-sdk-addon", () => {
         throw new Error("Agora App Id not set.");
     }
 
-    const AgoraRtcSDK = require("agora-electron-sdk").default;
-
-    const rtcEngine: AgoraRtcEngine = new AgoraRtcSDK();
+    const rtcEngine = new AgoraRtcSDK();
     window.rtcEngine = rtcEngine;
 
     if (rtcEngine.initialize(process.env.AGORA_APP_ID) < 0) {

--- a/desktop/main-app/src/utils/ipc-actions.ts
+++ b/desktop/main-app/src/utils/ipc-actions.ts
@@ -1,11 +1,10 @@
-import { windowManager } from "../window-manager";
-import { ipc } from "flat-types";
 import { app, ipcMain, powerSaveBlocker } from "electron";
+import { ipc, update } from "flat-types";
+import { gt } from "semver";
+import { windowManager } from "../window-manager";
+import { CustomWindow } from "../window-manager/abstract";
 import runtime from "./runtime";
 import { updateService } from "./update-service";
-import { update } from "flat-types";
-import { gt } from "semver";
-import { CustomWindow } from "../window-manager/abstract";
 
 const windowActionAsync = (customWindow: CustomWindow): ipc.WindowActionAsync => {
     const { window, options } = customWindow;

--- a/desktop/main-app/src/utils/ipc-emit.ts
+++ b/desktop/main-app/src/utils/ipc-emit.ts
@@ -1,8 +1,7 @@
-import { ipc } from "flat-types";
+import { constants, ipc } from "flat-types";
 import { windowManager } from "../window-manager";
-import runtime from "./runtime";
-import { constants } from "flat-types";
 import { CustomWindow, IsMultiInstance } from "../window-manager/abstract";
+import runtime from "./runtime";
 
 const sendIPC = (customWindow: CustomWindow | null, eventName: string, args: any): void => {
     if (customWindow) {

--- a/desktop/main-app/src/utils/runtime.ts
+++ b/desktop/main-app/src/utils/runtime.ts
@@ -1,6 +1,6 @@
+import { platform } from "os";
 import path from "path";
 import { app } from "electron";
-import { platform } from "os";
 import { runtime as Runtime } from "flat-types";
 
 const isDevelopment = process.env.NODE_ENV === "development";

--- a/desktop/main-app/src/utils/update-service.ts
+++ b/desktop/main-app/src/utils/update-service.ts
@@ -1,8 +1,8 @@
-import { autoUpdater, UpdateCheckResult } from "electron-updater";
-import runtime from "./runtime";
+import { UpdateCheckResult, autoUpdater } from "electron-updater";
 import { ProgressInfo } from "electron-updater/out/differentialDownloader/ProgressDifferentialDownloadCallbackTransform";
-import { ipcEmitByMain } from "./ipc-emit";
 import { update } from "flat-types";
+import { ipcEmitByMain } from "./ipc-emit";
+import runtime from "./runtime";
 
 class UpdateService {
     private cancellationToken: UpdateCheckResult["cancellationToken"];

--- a/desktop/main-app/src/utils/window-event.ts
+++ b/desktop/main-app/src/utils/window-event.ts
@@ -1,6 +1,6 @@
-import { ipcEmit } from "./ipc-emit";
 import { autoUpdater } from "electron-updater";
 import { CustomWindow } from "../window-manager/abstract";
+import { ipcEmit } from "./ipc-emit";
 
 export const windowHookClose = (customWindow: CustomWindow): void => {
     customWindow.window.on("close", e => {

--- a/desktop/main-app/src/window-manager/abstract.ts
+++ b/desktop/main-app/src/window-manager/abstract.ts
@@ -1,5 +1,5 @@
-import { constants } from "flat-types";
 import { BrowserWindow, BrowserWindowConstructorOptions } from "electron";
+import { constants } from "flat-types";
 import {
     windowHookClose,
     windowHookClosed,
@@ -7,9 +7,9 @@ import {
     windowReadyToShow,
 } from "../utils/window-event";
 import {
+    WindowOptions,
     defaultBrowserWindowOptions,
     defaultWindowOptions,
-    WindowOptions,
 } from "./default-options";
 
 export abstract class AbstractWindow<MULTI_INSTANCE extends boolean> {

--- a/desktop/main-app/src/window-manager/index.ts
+++ b/desktop/main-app/src/window-manager/index.ts
@@ -1,8 +1,8 @@
-import { WindowManager } from "./window-manager";
-import { WindowMain } from "./window-main";
 import { constants } from "flat-types";
-import { WindowShareScreenTip } from "./window-portal/window-share-screen-tip";
+import { WindowMain } from "./window-main";
+import { WindowManager } from "./window-manager";
 import { WindowPreviewFile } from "./window-portal/window-preview-file";
+import { WindowShareScreenTip } from "./window-portal/window-share-screen-tip";
 
 export const windowManager = new WindowManager({
     [constants.WindowsName.Main]: new WindowMain(),

--- a/desktop/main-app/src/window-manager/window-main/index.ts
+++ b/desktop/main-app/src/window-manager/window-main/index.ts
@@ -1,10 +1,10 @@
-import { constants } from "flat-types";
-import { AbstractWindow, CustomWindow } from "../abstract";
-import runtime from "../../utils/runtime";
-import { RxSubject } from "./rx-subject";
 import { ipcMain } from "electron";
+import { constants } from "flat-types";
 import { zip } from "rxjs";
 import { ignoreElements, mergeMap } from "rxjs/operators";
+import runtime from "../../utils/runtime";
+import { AbstractWindow, CustomWindow } from "../abstract";
+import { RxSubject } from "./rx-subject";
 
 export class WindowMain extends AbstractWindow<false> {
     private readonly subject: RxSubject;

--- a/desktop/main-app/src/window-manager/window-main/rx-subject.ts
+++ b/desktop/main-app/src/window-manager/window-main/rx-subject.ts
@@ -1,5 +1,5 @@
-import { Subject } from "rxjs";
 import { IpcMainEvent } from "electron";
+import { Subject } from "rxjs";
 
 export class RxSubject {
     public constructor(

--- a/desktop/main-app/src/window-manager/window-manager.ts
+++ b/desktop/main-app/src/window-manager/window-manager.ts
@@ -1,8 +1,8 @@
-import { constants, portal } from "flat-types";
 import { BrowserWindowConstructorOptions } from "electron";
-import { WindowStore } from "./window-store";
-import { CustomWindow, AbstractWindows } from "./abstract";
+import { constants, portal } from "flat-types";
 import { injectionWindowIPCAction } from "../utils/ipc-actions";
+import { AbstractWindows, CustomWindow } from "./abstract";
+import { WindowStore } from "./window-store";
 
 export class WindowManager<
     ABSTRACT_WINDOWS extends AbstractWindows,

--- a/desktop/main-app/src/window-manager/window-portal/utils.ts
+++ b/desktop/main-app/src/window-manager/window-portal/utils.ts
@@ -1,6 +1,6 @@
 import { Display, screen } from "electron";
-import { windowManager } from "../index";
 import { constants } from "flat-types";
+import { windowManager } from "../index";
 
 export const getDisplayByMainWindow = (): Display => {
     const mainBounds = windowManager

--- a/desktop/main-app/src/window-manager/window-portal/window-preview-file.ts
+++ b/desktop/main-app/src/window-manager/window-portal/window-preview-file.ts
@@ -1,5 +1,5 @@
-import { AbstractWindow, CustomWindow } from "../abstract";
 import { constants } from "flat-types";
+import { AbstractWindow, CustomWindow } from "../abstract";
 
 export class WindowPreviewFile extends AbstractWindow<true> {
     public constructor() {

--- a/desktop/main-app/src/window-manager/window-portal/window-share-screen-tip.ts
+++ b/desktop/main-app/src/window-manager/window-portal/window-share-screen-tip.ts
@@ -1,5 +1,5 @@
-import { AbstractWindow, CustomWindow } from "../abstract";
 import { constants } from "flat-types";
+import { AbstractWindow, CustomWindow } from "../abstract";
 import { getDisplayByMainWindow, getXCenterPoint } from "./utils";
 
 export class WindowShareScreenTip extends AbstractWindow<false> {

--- a/desktop/main-app/typings/globals.d.ts
+++ b/desktop/main-app/typings/globals.d.ts
@@ -1,6 +1,9 @@
+import AgoraRtcSDK from "agora-electron-sdk";
+import { Runtime } from "../src/utils/runtime";
+
 declare namespace NodeJS {
     export interface Global {
-        runtime: import("../src/utils/runtime").Runtime;
+        runtime: Runtime;
     }
 
     export interface ProcessEnv {
@@ -10,8 +13,10 @@ declare namespace NodeJS {
     }
 }
 
-interface Window {
-    rtcEngine: any;
-    $: any;
-    jQuery: any;
+declare global {
+    interface Window {
+        rtcEngine: AgoraRtcSDK;
+        $: any;
+        jQuery: any;
+    }
 }

--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -74,6 +74,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",

--- a/desktop/renderer-app/scripts/vite-plugin-electron/index.ts
+++ b/desktop/renderer-app/scripts/vite-plugin-electron/index.ts
@@ -1,7 +1,7 @@
 import { builtinModules } from "module";
 import { Plugin as VitePlugin } from "vite";
-import { cjs2esm } from "./utils";
 import { options } from "./template/options";
+import { cjs2esm } from "./utils";
 
 // based on https://github.com/caoxiemeihao/vite-plugins/blob/main/packages/electron/src/index.ts
 

--- a/desktop/renderer-app/scripts/vite-plugin-electron/utils.ts
+++ b/desktop/renderer-app/scripts/vite-plugin-electron/utils.ts
@@ -1,6 +1,6 @@
-import { build, OutputFile } from "esbuild";
 import { readFileSync } from "fs";
 import { join } from "path";
+import { OutputFile, build } from "esbuild";
 
 // e.g:
 // flat/node_modules/electron/index.js?v=19cea64f => flat/node_modules/electron/index.js

--- a/desktop/renderer-app/src/AppRoutes/AppRouteContainer.tsx
+++ b/desktop/renderer-app/src/AppRoutes/AppRouteContainer.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from "react";
-import { useIsomorphicLayoutEffect } from "react-use";
-import { RouteComponentProps } from "react-router-dom";
-import { ipcAsyncByMainWindow } from "../utils/ipc";
-import { AppRouteErrorBoundary } from "./AppRouteErrorBoundary";
-import { useURLAppLauncher } from "../utils/hooks/use-url-app-launcher";
-import { ConfigStoreContext } from "../components/StoreProvider";
 import { FlatThemeBodyProvider } from "flat-components";
 import { observer } from "mobx-react-lite";
+import { RouteComponentProps } from "react-router-dom";
+import { useIsomorphicLayoutEffect } from "react-use";
+import { ConfigStoreContext } from "../components/StoreProvider";
+import { useURLAppLauncher } from "../utils/hooks/use-url-app-launcher";
+import { ipcAsyncByMainWindow } from "../utils/ipc";
+import { AppRouteErrorBoundary } from "./AppRouteErrorBoundary";
 
 export interface AppRouteContainerProps {
     Comp: React.ComponentType<any>;

--- a/desktop/renderer-app/src/AppRoutes/AppRouteErrorBoundary.tsx
+++ b/desktop/renderer-app/src/AppRoutes/AppRouteErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType } from "react";
-import { RouteComponentProps } from "react-router-dom";
 import { ErrorPage } from "flat-components";
+import { RouteComponentProps } from "react-router-dom";
 
 export interface AppRouteErrorBoundaryProps {
     Comp: ComponentType<any>;

--- a/desktop/renderer-app/src/AppRoutes/index.tsx
+++ b/desktop/renderer-app/src/AppRoutes/index.tsx
@@ -1,5 +1,5 @@
-import { observer } from "mobx-react-lite";
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 import { HashRouter, Route, Switch } from "react-router-dom";
 import { LastLocationProvider } from "react-router-last-location";

--- a/desktop/renderer-app/src/api-middleware/cloud-recording.ts
+++ b/desktop/renderer-app/src/api-middleware/cloud-recording.ts
@@ -1,16 +1,16 @@
 import { updateRecordEndTime } from "./flatServer";
 import {
-    cloudRecordAcquire,
-    CloudRecordStopResult,
-    cloudRecordStop,
     CloudRecordAcquirePayload,
-    CloudRecordStartPayload,
-    cloudRecordStart,
     CloudRecordQueryResult,
-    cloudRecordQuery,
-    cloudRecordUpdateLayout,
+    CloudRecordStartPayload,
+    CloudRecordStopResult,
     CloudRecordUpdateLayoutPayload,
     CloudRecordUpdateLayoutResult,
+    cloudRecordAcquire,
+    cloudRecordQuery,
+    cloudRecordStart,
+    cloudRecordStop,
+    cloudRecordUpdateLayout,
 } from "./flatServer/agora";
 
 /**

--- a/desktop/renderer-app/src/api-middleware/flatServer/utils.ts
+++ b/desktop/renderer-app/src/api-middleware/flatServer/utils.ts
@@ -1,8 +1,8 @@
 import Axios, { AxiosRequestConfig } from "axios";
-import { globalStore } from "../../stores/global-store";
-import { FLAT_SERVER_VERSIONS, Status } from "./constants";
-import { ServerRequestError } from "../../utils/error/server-request-error";
 import { RequestErrorCode } from "../../constants/error-code";
+import { globalStore } from "../../stores/global-store";
+import { ServerRequestError } from "../../utils/error/server-request-error";
+import { FLAT_SERVER_VERSIONS, Status } from "./constants";
 
 export type FlatServerResponse<T> =
     | {

--- a/desktop/renderer-app/src/api-middleware/rtc.ts
+++ b/desktop/renderer-app/src/api-middleware/rtc.ts
@@ -1,4 +1,4 @@
-import type AgoraSdk from "agora-electron-sdk";
+import AgoraSdk from "agora-electron-sdk";
 import { AGORA } from "../constants/process";
 import { globalStore } from "../stores/global-store";
 import { generateRTCToken } from "./flatServer/agora";

--- a/desktop/renderer-app/src/api-middleware/rtm.ts
+++ b/desktop/renderer-app/src/api-middleware/rtm.ts
@@ -1,11 +1,11 @@
+import { EventEmitter } from "events";
 import AgoraRTM, { RtmChannel, RtmClient } from "agora-rtm-sdk";
 import polly from "polly-js";
 import { v4 as uuidv4 } from "uuid";
 import { AGORA, NODE_ENV } from "../constants/process";
-import { EventEmitter } from "events";
-import { RoomStatus } from "./flatServer/constants";
-import { generateRTMToken } from "./flatServer/agora";
 import { globalStore } from "../stores/global-store";
+import { generateRTMToken } from "./flatServer/agora";
+import { RoomStatus } from "./flatServer/constants";
 
 export interface RtmRESTfulQueryPayload {
     filter: {

--- a/desktop/renderer-app/src/api-middleware/share-screen.ts
+++ b/desktop/renderer-app/src/api-middleware/share-screen.ts
@@ -1,7 +1,7 @@
-import { globalStore } from "../stores/global-store";
-import { AGORA } from "../constants/process";
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { ScreenSymbol } from "agora-electron-sdk/types/Api/native_type";
+import { AGORA } from "../constants/process";
+import { globalStore } from "../stores/global-store";
 
 export class RTCShareScreen {
     public constructor(

--- a/desktop/renderer-app/src/api-middleware/smart-player.ts
+++ b/desktop/renderer-app/src/api-middleware/smart-player.ts
@@ -1,24 +1,23 @@
-import "video.js/dist/video-js.css";
-
+import { EventEmitter } from "events";
 import CombinePlayerFactory, { CombinePlayer, PublicCombinedStatus } from "@netless/combine-player";
 import {
+    PluginContext as VideoJsPluginContext,
     PluginId as VideoJsPluginId,
     videoJsPlugin,
-    PluginContext as VideoJsPluginContext,
 } from "@netless/video-js-plugin";
-import { EventEmitter } from "events";
+import { WindowManager } from "@netless/window-manager";
+import { Region } from "flat-components";
 import polly from "polly-js";
 import {
-    createPlugins,
     PlayableCheckingParams,
     Player,
     PlayerPhase,
     ReplayRoomParams,
     WhiteWebSdk,
+    createPlugins,
 } from "white-web-sdk";
-import { Region } from "flat-components";
 import { NETLESS, NODE_ENV } from "../constants/process";
-import { WindowManager } from "@netless/window-manager";
+import "video.js/dist/video-js.css";
 
 export enum SmartPlayerEventType {
     Ready = "Ready",

--- a/desktop/renderer-app/src/components/AppStoreButton/AppButton.tsx
+++ b/desktop/renderer-app/src/components/AppStoreButton/AppButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
+import { LoadingOutlined } from "@ant-design/icons";
 import { observer } from "mobx-react-lite";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
-import { LoadingOutlined } from "@ant-design/icons";
 
 export interface AppButtonProps {
     kind: string;

--- a/desktop/renderer-app/src/components/AppStoreButton/index.tsx
+++ b/desktop/renderer-app/src/components/AppStoreButton/index.tsx
@@ -1,18 +1,16 @@
-import "./style.less";
+import React, { useState } from "react";
+import { AddAppParams } from "@netless/window-manager";
+import { Modal } from "antd";
+import { TopBarRightBtn, useSafePromise } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import appStoreSVG from "../../assets/image/app-store.svg";
+import cocosSVG from "../../assets/image/cocos.svg";
 import codeEditorSVG from "../../assets/image/code-editor.svg";
 import countdownSVG from "../../assets/image/countdown.svg";
 import geogebraSVG from "../../assets/image/geogebra.svg";
-import cocosSVG from "../../assets/image/cocos.svg";
-
-import React, { useState } from "react";
-import { observer } from "mobx-react-lite";
-import { Modal } from "antd";
-
-import { AddAppParams } from "@netless/window-manager";
-import { TopBarRightBtn, useSafePromise } from "flat-components";
 import { AppButton } from "./AppButton";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface AppStoreButtonProps {
     addApp: (config: AddAppParams) => Promise<void>;

--- a/desktop/renderer-app/src/components/AppUpgradeModal/index.tsx
+++ b/desktop/renderer-app/src/components/AppUpgradeModal/index.tsx
@@ -1,10 +1,10 @@
-import "./index.less";
-import { Button, Modal } from "antd";
-import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
-import { ipcAsyncByApp, ipcReceive, ipcReceiveRemove } from "../../utils/ipc";
-import { useTranslation } from "react-i18next";
+import { Button, Modal } from "antd";
 import { update } from "flat-types";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { ipcAsyncByApp, ipcReceive, ipcReceiveRemove } from "../../utils/ipc";
+import "./index.less";
 
 export interface AppUpgradeModalProps {
     updateInfo:

--- a/desktop/renderer-app/src/components/AvatarCanvas.tsx
+++ b/desktop/renderer-app/src/components/AvatarCanvas.tsx
@@ -1,10 +1,9 @@
-import "./AvatarCanvas.less";
-
 import React, { useEffect, useRef } from "react";
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { observer } from "mobx-react-lite";
 import { useUpdateEffect } from "react-use";
 import { User } from "../stores/class-room-store";
+import "./AvatarCanvas.less";
 
 export interface AvatarCanvasProps {
     isCreator: boolean;

--- a/desktop/renderer-app/src/components/ChatPanel/index.tsx
+++ b/desktop/renderer-app/src/components/ChatPanel/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { ChatPanel as ChatPanelImpl, useComputed } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { ClassRoomStore } from "../../stores/class-room-store";
 import { generateAvatar } from "../../utils/generate-avatar";
 

--- a/desktop/renderer-app/src/components/ChatPanelReplay/ChatMessageListReplay.tsx
+++ b/desktop/renderer-app/src/components/ChatPanelReplay/ChatMessageListReplay.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Observer, observer } from "mobx-react-lite";
 import { ChatMessage } from "flat-components";
+import { Observer, observer } from "mobx-react-lite";
 import {
     AutoSizer,
     CellMeasurer,

--- a/desktop/renderer-app/src/components/ChatPanelReplay/ChatMessagesReplay.tsx
+++ b/desktop/renderer-app/src/components/ChatPanelReplay/ChatMessagesReplay.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { ChatMessageListReplay } from "./ChatMessageListReplay";
-import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { useTranslation } from "react-i18next";
+import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
+import { ChatMessageListReplay } from "./ChatMessageListReplay";
 
 export interface ChatMessagesReplayProps {
     classRoomReplayStore: ClassRoomReplayStore;

--- a/desktop/renderer-app/src/components/ChatPanelReplay/index.tsx
+++ b/desktop/renderer-app/src/components/ChatPanelReplay/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Tabs } from "antd";
 import { observer } from "mobx-react-lite";
-import { ChatMessagesReplay } from "./ChatMessagesReplay";
-import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { useTranslation } from "react-i18next";
+import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
+import { ChatMessagesReplay } from "./ChatMessagesReplay";
 
 export interface ChatPanelReplayProps {
     classRoomReplayStore: ClassRoomReplayStore;

--- a/desktop/renderer-app/src/components/ClassRoom/RoomStatusStoppedModal.tsx
+++ b/desktop/renderer-app/src/components/ClassRoom/RoomStatusStoppedModal.tsx
@@ -1,6 +1,6 @@
+import React, { useCallback } from "react";
 import { RoomStoppedModal } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback } from "react";
 import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RouteNameType, usePushHistory } from "../../utils/routes";
 

--- a/desktop/renderer-app/src/components/CloudStorageButton.tsx
+++ b/desktop/renderer-app/src/components/CloudStorageButton.tsx
@@ -1,14 +1,13 @@
 // TODO: remove this component when multi sub window is Done
-import "./CloudStorageButton.less";
-
-import { Modal } from "antd";
-import { observer } from "mobx-react-lite";
 import React, { useCallback } from "react";
-import { useTranslation } from "react-i18next";
-import { CloudStoragePanel } from "../pages/CloudStoragePage/CloudStoragePanel";
+import { Modal } from "antd";
 import { TopBarRightBtn } from "flat-components";
-import { ClassRoomStore } from "../stores/class-room-store";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import cloudStorageSVG from "../assets/image/cloud-storage.svg";
+import { CloudStoragePanel } from "../pages/CloudStoragePage/CloudStoragePanel";
+import { ClassRoomStore } from "../stores/class-room-store";
+import "./CloudStorageButton.less";
 
 interface CloudStorageButtonProps {
     classroom: ClassRoomStore;

--- a/desktop/renderer-app/src/components/EditRoomPage/index.tsx
+++ b/desktop/renderer-app/src/components/EditRoomPage/index.tsx
@@ -1,11 +1,10 @@
-import "./style.less";
-
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { EditRoomBody, EditRoomBodyProps, MainPageHeader } from "flat-components";
-import { MainPageLayoutContainer } from "../MainPageLayoutContainer";
-import { useHistory } from "react-router";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router";
+import { MainPageLayoutContainer } from "../MainPageLayoutContainer";
+import "./style.less";
 
 export type EditRoomPageProps = EditRoomBodyProps;
 

--- a/desktop/renderer-app/src/components/ExitRoomConfirm.tsx
+++ b/desktop/renderer-app/src/components/ExitRoomConfirm.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import {
     CloseRoomConfirmModal,
     ExitRoomConfirmModal,
     StopClassConfirmModal,
 } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { RoomStatus } from "../api-middleware/flatServer/constants";
 import { useSafePromise } from "../utils/hooks/lifecycle";
 import { ipcAsyncByMainWindow, ipcReceive, ipcReceiveRemove } from "../utils/ipc";

--- a/desktop/renderer-app/src/components/InviteButton.tsx
+++ b/desktop/renderer-app/src/components/InviteButton.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { observer } from "mobx-react-lite";
 import { TopBarRightBtn } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import inviteSVG from "../assets/image/invite.svg";
 import { RoomItem } from "../stores/room-store";
 import { InviteModal } from "./Modal/InviteModal";
-import inviteSVG from "../assets/image/invite.svg";
-import { useTranslation } from "react-i18next";
 
 export interface InviteButtonProps {
     roomInfo?: RoomItem;

--- a/desktop/renderer-app/src/components/MainBreadcrumb.tsx
+++ b/desktop/renderer-app/src/components/MainBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Breadcrumb } from "antd";
 import { HomeOutlined, UserOutlined } from "@ant-design/icons";
+import { Breadcrumb } from "antd";
 
 export default class MainBreadcrumb extends React.PureComponent<{}> {
     public render(): JSX.Element {

--- a/desktop/renderer-app/src/components/MainPageLayoutContainer/index.tsx
+++ b/desktop/renderer-app/src/components/MainPageLayoutContainer/index.tsx
@@ -1,24 +1,24 @@
 /* eslint react/display-name: off */
-import homeSVG from "./icons/home.svg";
-import homeActiveSVG from "./icons/home-active.svg";
-import diskSVG from "./icons/disk.svg";
-import diskActiveSVG from "./icons/disk-active.svg";
-import deviceSVG from "./icons/device.svg";
-import deviceActiveSVG from "./icons/device-active.svg";
-import settingSVG from "./icons/setting.svg";
-import gitHubSVG from "./icons/github.svg";
-import feedbackSVG from "./icons/feedback.svg";
-import logoutSVG from "./icons/logout.svg";
-import "./index.less";
 
 import React, { useContext } from "react";
 import { shell } from "electron";
-import { useHistory, useLocation } from "react-router-dom";
 import { MainPageLayout, MainPageLayoutItem, MainPageLayoutProps } from "flat-components";
 import { useTranslation } from "react-i18next";
-import { routeConfig, RouteNameType } from "../../route-config";
-import { GlobalStoreContext } from "../StoreProvider";
+import { useHistory, useLocation } from "react-router-dom";
+import { RouteNameType, routeConfig } from "../../route-config";
 import { generateAvatar } from "../../utils/generate-avatar";
+import { GlobalStoreContext } from "../StoreProvider";
+import deviceActiveSVG from "./icons/device-active.svg";
+import deviceSVG from "./icons/device.svg";
+import diskActiveSVG from "./icons/disk-active.svg";
+import diskSVG from "./icons/disk.svg";
+import feedbackSVG from "./icons/feedback.svg";
+import gitHubSVG from "./icons/github.svg";
+import homeActiveSVG from "./icons/home-active.svg";
+import homeSVG from "./icons/home.svg";
+import logoutSVG from "./icons/logout.svg";
+import settingSVG from "./icons/setting.svg";
+import "./index.less";
 
 export interface MainPageLayoutContainerProps {
     subMenu?: MainPageLayoutItem[];

--- a/desktop/renderer-app/src/components/Modal/ExitReplayConfirmModal.tsx
+++ b/desktop/renderer-app/src/components/Modal/ExitReplayConfirmModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal } from "antd";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 
 interface ExitReplayConfirmModalProps {

--- a/desktop/renderer-app/src/components/Modal/InviteModal.tsx
+++ b/desktop/renderer-app/src/components/Modal/InviteModal.tsx
@@ -1,15 +1,14 @@
-import "./InviteModal.less";
-
 import React, { useCallback, useContext, useEffect } from "react";
-import { observer } from "mobx-react-lite";
 import { message } from "antd";
+import { clipboard } from "electron";
 import { InviteModal as InviteModalImpl } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { RoomItem } from "../../stores/room-store";
 import { GlobalStoreContext, RoomStoreContext } from "../StoreProvider";
-import { clipboard } from "electron";
 import { errorTips } from "../Tips/ErrorTips";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
+import "./InviteModal.less";
 
 export interface InviteModalProps {
     visible: boolean;

--- a/desktop/renderer-app/src/components/Modal/RemoveHistoryRoomModal.tsx
+++ b/desktop/renderer-app/src/components/Modal/RemoveHistoryRoomModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal } from "antd";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 
 interface RemoveHistoryRoomModalProps {

--- a/desktop/renderer-app/src/components/RealtimePanel.tsx
+++ b/desktop/renderer-app/src/components/RealtimePanel.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import classNames from "classnames";
-
 import "./RealtimePanel.less";
 
 export type RealtimePanelProps = {

--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreen/index.tsx
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreen/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
-
 import React, { useEffect, useMemo, useRef } from "react";
-import { observer } from "mobx-react-lite";
 import classNames from "classnames";
-import type { ShareScreenStore } from "../../../stores/share-screen-store";
+import { observer } from "mobx-react-lite";
+import { ShareScreenStore } from "../../../stores/share-screen-store";
 import { ShareScreenTip } from "../ShareScreenTip";
+import "./style.less";
 
 interface ShareScreenProps {
     shareScreenStore: ShareScreenStore;

--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/ScreenList/index.tsx
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/ScreenList/index.tsx
@@ -1,12 +1,12 @@
-import "./style.less";
 import React, { useCallback, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
-import { ScreenInfo, ShareSymbol } from "../../../../api-middleware/share-screen";
-import { getScreenInfo, uint8ArrayToImageURL } from "./Utils";
-import classNames from "classnames";
-import { ShareScreenStore } from "../../../../stores/share-screen-store";
 import { message } from "antd";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { ScreenInfo, ShareSymbol } from "../../../../api-middleware/share-screen";
+import { ShareScreenStore } from "../../../../stores/share-screen-store";
+import { getScreenInfo, uint8ArrayToImageURL } from "./Utils";
+import "./style.less";
 
 interface ScreenListProps {
     screenInfo: ScreenInfo;

--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/index.tsx
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreenPicker/index.tsx
@@ -1,11 +1,11 @@
-import "./style.less";
 import React, { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal, Spin } from "antd";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { ShareScreenStore } from "../../../stores/share-screen-store";
 import { ScreenList } from "./ScreenList";
-import classNames from "classnames";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 interface ShareScreenPickerProps {
     shareScreenStore: ShareScreenStore;

--- a/desktop/renderer-app/src/components/ShareScreen/ShareScreenTip/index.tsx
+++ b/desktop/renderer-app/src/components/ShareScreen/ShareScreenTip/index.tsx
@@ -1,15 +1,14 @@
-import React from "react";
-import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
-import ReactDOM from "react-dom";
-import "./style.less";
-import { portalWindowManager } from "../../../utils/portal-window-manager";
-import { ipcAsyncByShareScreenTipWindow } from "../../../utils/ipc";
-import dragSVG from "../../../assets/image/drag.svg";
+import React, { useEffect, useState } from "react";
 import { Button } from "antd";
-import { ShareScreenStore } from "../../../stores/share-screen-store";
+import { observer } from "mobx-react-lite";
+import ReactDOM from "react-dom";
 import { useTranslation } from "react-i18next";
+import dragSVG from "../../../assets/image/drag.svg";
+import { ShareScreenStore } from "../../../stores/share-screen-store";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
+import { ipcAsyncByShareScreenTipWindow } from "../../../utils/ipc";
+import { portalWindowManager } from "../../../utils/portal-window-manager";
+import "./style.less";
 
 interface ShareScreenTipProps {
     shareScreenStore: ShareScreenStore;

--- a/desktop/renderer-app/src/components/StoreProvider.tsx
+++ b/desktop/renderer-app/src/components/StoreProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC } from "react";
+import React, { FC, createContext } from "react";
 import { configStore } from "../stores/config-store";
 import { globalStore } from "../stores/global-store";
 import { roomStore } from "../stores/room-store";

--- a/desktop/renderer-app/src/components/Tips/ErrorTips.tsx
+++ b/desktop/renderer-app/src/components/Tips/ErrorTips.tsx
@@ -1,6 +1,6 @@
 import { message } from "antd";
-import { ServerRequestError } from "../../utils/error/server-request-error";
 import { NODE_ENV } from "../../constants/process";
+import { ServerRequestError } from "../../utils/error/server-request-error";
 import { i18n } from "../../utils/i18n";
 
 export const errorTips = (e: unknown): void => {

--- a/desktop/renderer-app/src/components/WeekRateSelector.tsx
+++ b/desktop/renderer-app/src/components/WeekRateSelector.tsx
@@ -1,9 +1,9 @@
-import { Select } from "antd";
-import { addDays, format, startOfWeek } from "date-fns";
 import React, { FC } from "react";
+import { Select } from "antd";
+import { SelectProps } from "antd/lib/select";
+import { addDays, format, startOfWeek } from "date-fns";
 import { zhCN } from "date-fns/locale";
 import { Week } from "../api-middleware/flatServer/constants";
-import { SelectProps } from "antd/lib/select";
 
 export type WeekRateSelectorProps = SelectProps<Week[]>;
 

--- a/desktop/renderer-app/src/components/Whiteboard.tsx
+++ b/desktop/renderer-app/src/components/Whiteboard.tsx
@@ -1,20 +1,20 @@
-import "@netless/window-manager/dist/style.css";
-import "./Whiteboard.less";
-
+import React, { useCallback, useEffect, useState } from "react";
 import RedoUndo from "@netless/redo-undo";
 import ToolBox from "@netless/tool-box";
 import { WindowManager } from "@netless/window-manager";
+import { message } from "antd";
 import classNames from "classnames";
 import { RaiseHand, ScenesController } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback, useEffect, useState } from "react";
-import { message } from "antd";
 import { useTranslation } from "react-i18next";
 import { RoomPhase } from "white-web-sdk";
+import { ClassRoomStore } from "../stores/class-room-store";
 import { WhiteboardStore } from "../stores/whiteboard-store";
 import { isSupportedFileExt } from "../utils/drag-and-drop";
 import { isSupportedImageType, onDropImage } from "../utils/drag-and-drop/image";
-import { ClassRoomStore } from "../stores/class-room-store";
+import "@netless/window-manager/dist/style.css";
+// eslint-disable-next-line import/order
+import "./Whiteboard.less";
 
 export interface WhiteboardProps {
     whiteboardStore: WhiteboardStore;

--- a/desktop/renderer-app/src/components/antd-date-fns.tsx
+++ b/desktop/renderer-app/src/components/antd-date-fns.tsx
@@ -2,9 +2,9 @@
 
 import React, { FC, useContext } from "react";
 import { Col, Row } from "antd";
-import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
-import generatePicker, { PickerTimeProps, PickerProps } from "antd/es/date-picker/generatePicker";
+import generatePicker, { PickerProps, PickerTimeProps } from "antd/es/date-picker/generatePicker";
 import { ConfigContext } from "antd/lib/config-provider";
+import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
 import "antd/es/date-picker/style/index";
 
 export type DatePickerProps = PickerProps<Date>;

--- a/desktop/renderer-app/src/pages/BigClassPage/BigClassAvatar.tsx
+++ b/desktop/renderer-app/src/pages/BigClassPage/BigClassAvatar.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from "react";
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { BigVideoAvatar } from "flat-components";
+import { VideoAvatarProps } from "flat-components/src/components/ClassroomPage/VideoAvatar";
 import { AvatarCanvas } from "../../components/AvatarCanvas";
 import { User } from "../../stores/user-store";
-import { VideoAvatarProps } from "flat-components/src/components/ClassroomPage/VideoAvatar";
 
 interface BigClassAvatarProps extends Omit<VideoAvatarProps, "avatarUser"> {
     rtcEngine: AgoraSDK;

--- a/desktop/renderer-app/src/pages/BigClassPage/index.tsx
+++ b/desktop/renderer-app/src/pages/BigClassPage/index.tsx
@@ -1,24 +1,29 @@
-import "./BigClassPage.less";
-
+import React, { useEffect, useRef, useState } from "react";
 import { message } from "antd";
 import classNames from "classnames";
 import {
+    CloudRecordBtn,
+    LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
-    LoadingPage,
-    CloudRecordBtn,
-    Timer,
+    TopBarRightBtn,
 } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { RoomPhase } from "white-web-sdk";
-import { useTranslation } from "react-i18next";
 import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
 import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RtcChannelType } from "../../api-middleware/rtc";
+import exitSVG from "../../assets/image/exit.svg";
+import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import hideSideSVG from "../../assets/image/hide-side.svg";
+import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
+import shareScreenSVG from "../../assets/image/share-screen.svg";
+import { AppStoreButton } from "../../components/AppStoreButton";
 import { ChatPanel } from "../../components/ChatPanel";
 import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
 import { CloudStorageButton } from "../../components/CloudStorageButton";
@@ -29,23 +34,17 @@ import {
 } from "../../components/ExitRoomConfirm";
 import InviteButton from "../../components/InviteButton";
 import { RealtimePanel } from "../../components/RealtimePanel";
-import { TopBarRightBtn } from "flat-components";
+import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
 import { Whiteboard } from "../../components/Whiteboard";
-import { RecordingConfig, useClassRoomStore, User } from "../../stores/class-room-store";
+import { RecordingConfig, User, useClassRoomStore } from "../../stores/class-room-store";
+import { generateAvatar } from "../../utils/generate-avatar";
 import { usePowerSaveBlocker } from "../../utils/hooks/use-power-save-blocker";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
 import { useAutoRun, useReaction } from "../../utils/mobx";
 import { RouteNameType, RouteParams } from "../../utils/routes";
-import { BigClassAvatar } from "./BigClassAvatar";
 import { runtime } from "../../utils/runtime";
-import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
-import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
-import shareScreenSVG from "../../assets/image/share-screen.svg";
-import exitSVG from "../../assets/image/exit.svg";
-import hideSideSVG from "../../assets/image/hide-side.svg";
-import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import { BigClassAvatar } from "./BigClassAvatar";
+import "./BigClassPage.less";
 
 const recordingConfig: RecordingConfig = Object.freeze({
     channelType: RtcChannelType.Broadcast,

--- a/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/DynamicPreview.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/DynamicPreview.tsx
@@ -1,11 +1,10 @@
-import "./DynamicPreview.less";
-
 import React, { useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
+import { SlidePreviewer, previewSlide } from "@netless/app-slide";
 import { Region } from "flat-components";
-import { previewSlide, SlidePreviewer } from "@netless/app-slide";
-import { useSafePromise } from "../../../utils/hooks/lifecycle";
+import { observer } from "mobx-react-lite";
 import { queryConvertingTaskStatus } from "../../../api-middleware/courseware-converting";
+import { useSafePromise } from "../../../utils/hooks/lifecycle";
+import "./DynamicPreview.less";
 
 export interface DynamicPreviewProps {
     taskUUID: string;

--- a/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/MediaPreview.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/MediaPreview.tsx
@@ -1,8 +1,7 @@
-import "./MediaPreview.less";
-
 import React from "react";
 import { observer } from "mobx-react-lite";
 import { getFileSuffix } from "./utils";
+import "./MediaPreview.less";
 
 export interface MediaPreviewProps {
     fileURL: string;

--- a/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/StaticPreview.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/StaticPreview.tsx
@@ -1,10 +1,9 @@
-import "./StaticPreview.less";
-
-import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
-import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { queryConvertingTaskStatus } from "../../../api-middleware/courseware-converting";
 import { Region } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { queryConvertingTaskStatus } from "../../../api-middleware/courseware-converting";
+import { useSafePromise } from "../../../utils/hooks/lifecycle";
+import "./StaticPreview.less";
 
 export interface StaticPreviewProps {
     taskUUID: string;

--- a/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/index.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/CloudStorageFilePreview/index.tsx
@@ -1,15 +1,14 @@
-import "./style.less";
-
+import React, { useRef } from "react";
 import { Region } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useRef } from "react";
+import ReactDOM from "react-dom";
+import { ipcAsyncByPreviewFileWindow } from "../../../utils/ipc";
+import { portalWindowManager } from "../../../utils/portal-window-manager";
 import { DynamicPreview } from "./DynamicPreview";
 import { MediaPreview } from "./MediaPreview";
 import { StaticPreview } from "./StaticPreview";
 import { getFileSuffix } from "./utils";
-import ReactDOM from "react-dom";
-import { portalWindowManager } from "../../../utils/portal-window-manager";
-import { ipcAsyncByPreviewFileWindow } from "../../../utils/ipc";
+import "./style.less";
 
 export type FileInfo = {
     fileURL: string;

--- a/desktop/renderer-app/src/pages/CloudStoragePage/CloudStoragePanel.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/CloudStoragePanel.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
+import React, { useEffect } from "react";
 import { CloudStorageContainer } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useEffect } from "react";
 import { CloudStorageStore } from "./store";
+import "./style.less";
 
 export interface CloudStoragePanelProps {
     cloudStorage: CloudStorageStore;

--- a/desktop/renderer-app/src/pages/CloudStoragePage/index.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/index.tsx
@@ -1,15 +1,14 @@
-import "./style.less";
-
+import React, { useEffect, useState } from "react";
 import { CloudStorageContainer } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
-import { CloudStorageStore } from "./store";
 import { loginCheck } from "../../api-middleware/flatServer";
-import { ServerRequestError } from "../../utils/error/server-request-error";
+import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
 import { RequestErrorCode } from "../../constants/error-code";
+import { ServerRequestError } from "../../utils/error/server-request-error";
 import { RouteNameType, useReplaceHistory } from "../../utils/routes";
+import { CloudStorageStore } from "./store";
+import "./style.less";
 
 export interface CloudStoragePageProps {}
 

--- a/desktop/renderer-app/src/pages/CloudStoragePage/store.tsx
+++ b/desktop/renderer-app/src/pages/CloudStoragePage/store.tsx
@@ -1,41 +1,41 @@
+import React, { ReactNode } from "react";
 import { Modal } from "antd";
 import {
     CloudStorageConvertStatusType,
-    CloudStorageFile as CloudStorageFileUI,
     CloudStorageFileName,
+    CloudStorageFile as CloudStorageFileUI,
     CloudStorageStore as CloudStorageStoreBase,
     CloudStorageUploadStatusType,
     CloudStorageUploadTask,
     FileUUID,
     UploadID,
 } from "flat-components";
-import type { i18n } from "i18next";
+import { i18n } from "i18next";
 import { action, computed, makeObservable, observable, reaction, runInAction } from "mobx";
-import React, { ReactNode } from "react";
 import {
     ConvertingTaskStatus,
     queryConvertingTaskStatus,
 } from "../../api-middleware/courseware-converting";
 import { FileConvertStep } from "../../api-middleware/flatServer/constants";
 import {
-    addExternalFile,
     CloudFile,
+    addExternalFile,
     convertFinish,
     convertStart,
     listFiles,
-    removeFiles,
     removeExternalFiles,
-    renameFile,
+    removeFiles,
     renameExternalFile,
+    renameFile,
 } from "../../api-middleware/flatServer/storage";
+import { queryH5ConvertingStatus } from "../../api-middleware/h5-converting";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { getCoursewarePreloader } from "../../utils/courseware-preloader";
+import { getFileExt, isPPTX } from "../../utils/file";
 import { getUploadTaskManager } from "../../utils/upload-task-manager";
 import { UploadStatusType, UploadTask } from "../../utils/upload-task-manager/upload-task";
-import { createResourcePreview, FileInfo } from "./CloudStorageFilePreview";
-import { getFileExt, isPPTX } from "../../utils/file";
+import { FileInfo, createResourcePreview } from "./CloudStorageFilePreview";
 import { ConvertStatusManager } from "./ConvertStatusManager";
-import { queryH5ConvertingStatus } from "../../api-middleware/h5-converting";
 
 export type CloudStorageFile = CloudStorageFileUI &
     Pick<CloudFile, "fileURL" | "taskUUID" | "taskToken" | "region" | "external">;

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/CameraCheckPage/index.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/CameraCheckPage/index.tsx
@@ -1,15 +1,14 @@
-import "./index.less";
-
 import React, { useEffect, useRef, useState } from "react";
 import { Button } from "antd";
+import { useTranslation } from "react-i18next";
 import { useHistory, useLocation } from "react-router-dom";
 import { DeviceSelect } from "../../../components/DeviceSelect";
+import { routeConfig } from "../../../route-config";
 import { Device } from "../../../types/device";
 import { useRTCEngine } from "../../../utils/hooks/use-rtc-engine";
 import { DeviceCheckLayoutContainer } from "../DeviceCheckLayoutContainer";
-import { routeConfig } from "../../../route-config";
 import { DeviceCheckResults } from "../utils";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 export const CameraCheckPage = (): React.ReactElement => {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/DeviceCheckLayoutContainer.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/DeviceCheckLayoutContainer.tsx
@@ -1,18 +1,18 @@
 /* eslint react/display-name: off */
-import systemSVG from "./icons/system.svg";
-import cameraSVG from "./icons/camera.svg";
-import speakerSVG from "./icons/speaker.svg";
-import microphoneSVG from "./icons/microphone.svg";
-import "./DeviceCheckLayoutContainer.less";
 
 import React from "react";
-import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
-import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { routeConfig, RouteNameType } from "../../route-config";
-import { useHistory, useLocation } from "react-router-dom";
-import { DeviceCheckState } from "./utils";
 import { MainPageLayoutItem } from "flat-components";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
+import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
+import { RouteNameType, routeConfig } from "../../route-config";
+import { useWindowSize } from "../../utils/hooks/use-window-size";
+import cameraSVG from "./icons/camera.svg";
+import microphoneSVG from "./icons/microphone.svg";
+import speakerSVG from "./icons/speaker.svg";
+import systemSVG from "./icons/system.svg";
+import { DeviceCheckState } from "./utils";
+import "./DeviceCheckLayoutContainer.less";
 
 export const DeviceCheckLayoutContainer: React.FC = ({ children }): React.ReactElement => {
     useWindowSize("Main");

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/MicrophoneCheckPage/index.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/MicrophoneCheckPage/index.tsx
@@ -1,18 +1,17 @@
-import infoSVG from "../../../assets/image/info.svg";
-import successSVG from "../../../assets/image/success.svg";
-import "./index.less";
-
 import React, { useEffect, useState } from "react";
 import { Button, Modal } from "antd";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
+import infoSVG from "../../../assets/image/info.svg";
+import successSVG from "../../../assets/image/success.svg";
 import { DeviceSelect } from "../../../components/DeviceSelect";
+import { routeConfig } from "../../../route-config";
 import { Device } from "../../../types/device";
 import { useRTCEngine } from "../../../utils/hooks/use-rtc-engine";
 import { DeviceCheckLayoutContainer } from "../DeviceCheckLayoutContainer";
-import { useHistory, useLocation } from "react-router-dom";
 import { DeviceCheckResults, DeviceCheckState } from "../utils";
-import { routeConfig } from "../../../route-config";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 interface SpeakerVolumeProps {
     percent: number;

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/SpeakerCheckPage/index.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/SpeakerCheckPage/index.tsx
@@ -1,23 +1,22 @@
+import React, { useEffect, useState } from "react";
+import path from "path";
+import { Button, Slider } from "antd";
+import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
+import muteSVG from "../../../assets/image/mute.svg";
 import playSVG from "../../../assets/image/play.svg";
 import stopSVG from "../../../assets/image/stop.svg";
-import muteSVG from "../../../assets/image/mute.svg";
 import volumeSVG from "../../../assets/image/volume.svg";
-import "./index.less";
-
-import React, { useEffect, useState } from "react";
-import { Slider, Button } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
-// let webpack recognize
-import "../../../assets/media/Goldberg Variations, BWV 988 - 05 - Variatio 4 a 1 Clav.mp3";
 import { DeviceSelect } from "../../../components/DeviceSelect";
+import { routeConfig } from "../../../route-config";
 import { Device } from "../../../types/device";
 import { useRTCEngine } from "../../../utils/hooks/use-rtc-engine";
-import { DeviceCheckLayoutContainer } from "../DeviceCheckLayoutContainer";
 import { runtime } from "../../../utils/runtime";
-import { routeConfig } from "../../../route-config";
+import { DeviceCheckLayoutContainer } from "../DeviceCheckLayoutContainer";
+// let webpack recognize
 import { DeviceCheckResults } from "../utils";
-import { useTranslation } from "react-i18next";
-import path from "path";
+import "../../../assets/media/Goldberg Variations, BWV 988 - 05 - Variatio 4 a 1 Clav.mp3";
+import "./index.less";
 
 export const SpeakerCheckPage = (): React.ReactElement => {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/DeviceCheckPages/SystemCheckPage/index.tsx
+++ b/desktop/renderer-app/src/pages/DeviceCheckPages/SystemCheckPage/index.tsx
@@ -1,13 +1,13 @@
-import "./index.less";
 import React, { useEffect, useState } from "react";
-import { Button } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
 import os from "os";
+import { Button } from "antd";
+import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
 import { routeConfig } from "../../../route-config";
 import { useRTCEngine } from "../../../utils/hooks/use-rtc-engine";
 import { DeviceCheckLayoutContainer } from "../DeviceCheckLayoutContainer";
 import { DeviceCheckResults, DeviceCheckState } from "../utils";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 export const SystemCheckPage = (): React.ReactElement => {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomHistoryPanel/index.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomHistoryPanel/index.tsx
@@ -1,11 +1,11 @@
 // import "../MainRoomListPanel/MainRoomList.less";
 
 import React from "react";
-import { observer } from "mobx-react-lite";
-import { MainRoomList } from "../MainRoomListPanel/MainRoomList";
-import { ListRoomsType } from "../../../api-middleware/flatServer";
 import { RoomList } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { MainRoomList } from "../MainRoomListPanel/MainRoomList";
 
 export const MainRoomHistoryPanel = observer<{ isLogin: boolean }>(function MainRoomHistoryPanel({
     isLogin,

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomListPanel/MainRoomList.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomListPanel/MainRoomList.tsx
@@ -1,8 +1,7 @@
-import { clipboard } from "electron";
-import { message } from "antd";
 import React, { Fragment, useCallback, useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
+import { message } from "antd";
 import { isSameDay } from "date-fns";
+import { clipboard } from "electron";
 import {
     InviteModal,
     RemoveRoomModal,
@@ -14,17 +13,18 @@ import {
     RoomListSkeletons,
     RoomStatusType,
 } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { ListRoomsType } from "../../../api-middleware/flatServer";
 import { RoomStatus, RoomType } from "../../../api-middleware/flatServer/constants";
 import { RemoveHistoryRoomModal } from "../../../components/Modal/RemoveHistoryRoomModal";
 import { GlobalStoreContext, RoomStoreContext } from "../../../components/StoreProvider";
 import { errorTips } from "../../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../../constants/process";
 import { RoomItem } from "../../../stores/room-store";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
 import { RouteNameType, usePushHistory } from "../../../utils/routes";
 import { joinRoomHandler } from "../../utils/join-room-handler";
-import { FLAT_WEB_BASE_URL } from "../../../constants/process";
-import { useTranslation } from "react-i18next";
 
 export interface MainRoomListProps {
     listRoomsType: ListRoomsType;

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomListPanel/index.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomListPanel/index.tsx
@@ -1,11 +1,10 @@
-import "./style.less";
-
 import React, { useMemo, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { RoomList } from "flat-components";
-import { MainRoomList } from "./MainRoomList";
-import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { MainRoomList } from "./MainRoomList";
+import "./style.less";
 
 export const MainRoomListPanel = observer<{ isLogin: boolean }>(function MainRoomListPanel({
     isLogin,

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/CreateRoomBox.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/CreateRoomBox.tsx
@@ -1,14 +1,13 @@
-import createSVG from "../../../assets/image/creat.svg";
-import "./CreateRoomBox.less";
-
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { Button, Checkbox, Dropdown, Form, Input, Menu, Modal } from "antd";
+import { ClassPicker, Region, RegionSVG, regions } from "flat-components";
 import { observer } from "mobx-react-lite";
-import { Button, Input, Modal, Checkbox, Form, Menu, Dropdown } from "antd";
+import { useTranslation } from "react-i18next";
 import { RoomType } from "../../../api-middleware/flatServer/constants";
+import createSVG from "../../../assets/image/creat.svg";
 import { ConfigStoreContext, GlobalStoreContext } from "../../../components/StoreProvider";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { ClassPicker, Region, regions, RegionSVG } from "flat-components";
-import { useTranslation } from "react-i18next";
+import "./CreateRoomBox.less";
 
 interface CreateRoomFormValues {
     roomTitle: string;

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/JoinRoomBox.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/JoinRoomBox.tsx
@@ -1,13 +1,12 @@
-import joinSVG from "../../../assets/image/join.svg";
-import "./JoinRoomBox.less";
-
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { Button, Checkbox, Form, Input, Modal } from "antd";
 import { observer } from "mobx-react-lite";
-import { Button, Input, Modal, Checkbox, Form } from "antd";
+import { useTranslation } from "react-i18next";
 import { validate, version } from "uuid";
+import joinSVG from "../../../assets/image/join.svg";
 import { ConfigStoreContext } from "../../../components/StoreProvider";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { useTranslation } from "react-i18next";
+import "./JoinRoomBox.less";
 
 interface JoinRoomFormValues {
     roomUUID: string;

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/ScheduleRoomBox.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/ScheduleRoomBox.tsx
@@ -1,9 +1,8 @@
-import bookSVG from "../../../assets/image/book.svg";
-
 import React from "react";
 import { Button } from "antd";
-import { RouteNameType, usePushHistory } from "../../../utils/routes";
 import { useTranslation } from "react-i18next";
+import bookSVG from "../../../assets/image/book.svg";
+import { RouteNameType, usePushHistory } from "../../../utils/routes";
 
 export const ScheduleRoomBox = React.memo<{}>(function ScheduleRoomBox() {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/index.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/MainRoomMenu/index.tsx
@@ -1,15 +1,14 @@
-import "./MainRoomMenu.less";
-
 import React, { FC, useContext } from "react";
 import { Region } from "flat-components";
 import { RoomType } from "../../../api-middleware/flatServer/constants";
 import { RoomStoreContext } from "../../../components/StoreProvider";
+import { errorTips } from "../../../components/Tips/ErrorTips";
 import { usePushHistory } from "../../../utils/routes";
+import { joinRoomHandler } from "../../utils/join-room-handler";
 import { CreateRoomBox } from "./CreateRoomBox";
 import { JoinRoomBox } from "./JoinRoomBox";
 import { ScheduleRoomBox } from "./ScheduleRoomBox";
-import { joinRoomHandler } from "../../utils/join-room-handler";
-import { errorTips } from "../../../components/Tips/ErrorTips";
+import "./MainRoomMenu.less";
 
 export const MainRoomMenu: FC = () => {
     const roomStore = useContext(RoomStoreContext);

--- a/desktop/renderer-app/src/pages/HomePage/index.tsx
+++ b/desktop/renderer-app/src/pages/HomePage/index.tsx
@@ -1,23 +1,22 @@
-import "./HomePage.less";
-
 import React, { useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
-import { ipcAsyncByMainWindow, ipcSyncByApp } from "../../utils/ipc";
-import { MainRoomMenu } from "./MainRoomMenu";
-import { MainRoomListPanel } from "./MainRoomListPanel";
-import { MainRoomHistoryPanel } from "./MainRoomHistoryPanel";
-import { useLastLocation } from "react-router-last-location";
-import { shouldWindowCenter } from "./utils";
-import { constants } from "flat-types";
-import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
-import { AppUpgradeModal, AppUpgradeModalProps } from "../../components/AppUpgradeModal";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import { runtime } from "../../utils/runtime";
-import { globalStore } from "../../stores/global-store";
 import { differenceInHours } from "date-fns";
-import { errorTips } from "../../components/Tips/ErrorTips";
+import { constants } from "flat-types";
+import { observer } from "mobx-react-lite";
+import { useLastLocation } from "react-router-last-location";
 import { loginCheck } from "../../api-middleware/flatServer";
+import { AppUpgradeModal, AppUpgradeModalProps } from "../../components/AppUpgradeModal";
+import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
+import { errorTips } from "../../components/Tips/ErrorTips";
+import { globalStore } from "../../stores/global-store";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
+import { ipcAsyncByMainWindow, ipcSyncByApp } from "../../utils/ipc";
 import { RouteNameType, useReplaceHistory } from "../../utils/routes";
+import { runtime } from "../../utils/runtime";
+import { MainRoomHistoryPanel } from "./MainRoomHistoryPanel";
+import { MainRoomListPanel } from "./MainRoomListPanel";
+import { MainRoomMenu } from "./MainRoomMenu";
+import { shouldWindowCenter } from "./utils";
+import "./HomePage.less";
 
 export type HomePageProps = {};
 

--- a/desktop/renderer-app/src/pages/HomePage/utils.ts
+++ b/desktop/renderer-app/src/pages/HomePage/utils.ts
@@ -1,5 +1,5 @@
-import { routeConfig } from "../../route-config";
 import { matchPath } from "react-router-dom";
+import { routeConfig } from "../../route-config";
 
 export const shouldWindowCenter = (pathname?: string): boolean => {
     if (!pathname) {

--- a/desktop/renderer-app/src/pages/LoginPage/WeChatLogin.tsx
+++ b/desktop/renderer-app/src/pages/LoginPage/WeChatLogin.tsx
@@ -1,19 +1,18 @@
-import "./WeChatLogin.less";
-
 import React, { useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { LoadingOutlined } from "@ant-design/icons";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
-import { UserInfo } from "../../stores/global-store";
 import { loginProcess, setAuthUUID } from "../../api-middleware/flatServer";
 import { FLAT_SERVER_LOGIN } from "../../api-middleware/flatServer/constants";
 import { GlobalStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { WECHAT } from "../../constants/process";
 import { RouteNameType } from "../../route-config";
+import { UserInfo } from "../../stores/global-store";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { usePushHistory } from "../../utils/routes";
-import { useTranslation } from "react-i18next";
+import "./WeChatLogin.less";
 
 export const WeChatLogin = observer(function WeChatLogin() {
     const globalStore = useContext(GlobalStoreContext);

--- a/desktop/renderer-app/src/pages/LoginPage/githubLogin.ts
+++ b/desktop/renderer-app/src/pages/LoginPage/githubLogin.ts
@@ -1,10 +1,10 @@
-import { setAuthUUID, loginProcess } from "../../api-middleware/flatServer";
-import { v4 as uuidv4 } from "uuid";
-import { LoginExecutor } from "./utils";
 import { shell } from "electron";
-import { errorTips } from "../../components/Tips/ErrorTips";
+import { v4 as uuidv4 } from "uuid";
+import { loginProcess, setAuthUUID } from "../../api-middleware/flatServer";
 import { FLAT_SERVER_LOGIN } from "../../api-middleware/flatServer/constants";
+import { errorTips } from "../../components/Tips/ErrorTips";
 import { GITHUB } from "../../constants/process";
+import { LoginExecutor } from "./utils";
 
 export const githubLogin: LoginExecutor = onSuccess => {
     let timer = NaN;

--- a/desktop/renderer-app/src/pages/LoginPage/index.tsx
+++ b/desktop/renderer-app/src/pages/LoginPage/index.tsx
@@ -1,25 +1,24 @@
-import "./index.less";
-
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { LoginChannelType, LoginPanel } from "flat-components";
 import { constants } from "flat-types";
 import { observer } from "mobx-react-lite";
-import { ipcAsyncByMainWindow, ipcSyncByApp } from "../../utils/ipc";
-import { LoginChannelType, LoginPanel } from "flat-components";
-import { LoginDisposer } from "./utils";
-import { githubLogin } from "./githubLogin";
-import { RouteNameType, usePushHistory } from "../../utils/routes";
-import { GlobalStoreContext } from "../../components/StoreProvider";
-import { AppUpgradeModal, AppUpgradeModalProps } from "../../components/AppUpgradeModal";
-import { runtime } from "../../utils/runtime";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import { WeChatLogin } from "./WeChatLogin";
 import { useTranslation } from "react-i18next";
+import { AppUpgradeModal, AppUpgradeModalProps } from "../../components/AppUpgradeModal";
+import { GlobalStoreContext } from "../../components/StoreProvider";
 import {
-    PRIVACY_URL_EN,
     PRIVACY_URL_CN,
-    SERVICE_URL_EN,
+    PRIVACY_URL_EN,
     SERVICE_URL_CN,
+    SERVICE_URL_EN,
 } from "../../constants/process";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
+import { ipcAsyncByMainWindow, ipcSyncByApp } from "../../utils/ipc";
+import { RouteNameType, usePushHistory } from "../../utils/routes";
+import { runtime } from "../../utils/runtime";
+import { githubLogin } from "./githubLogin";
+import { LoginDisposer } from "./utils";
+import { WeChatLogin } from "./WeChatLogin";
+import "./index.less";
 
 export const LoginPage = observer(function LoginPage() {
     const { i18n } = useTranslation();

--- a/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/OrdinaryRoomForm.tsx
+++ b/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/OrdinaryRoomForm.tsx
@@ -1,12 +1,12 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
+import { message } from "antd";
+import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory } from "react-router-dom";
-import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { ordinaryRoomInfo, updateOrdinaryRoom } from "../../api-middleware/flatServer";
 import EditRoomPage from "../../components/EditRoomPage";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 export interface OrdinaryRoomFormProps {
     roomUUID: string;
 }

--- a/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/PeriodicSubRoomForm.tsx
+++ b/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/PeriodicSubRoomForm.tsx
@@ -1,12 +1,12 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
+import { message } from "antd";
+import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory } from "react-router-dom";
-import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { periodicSubRoomInfo, updatePeriodicSubRoom } from "../../api-middleware/flatServer";
 import EditRoomPage from "../../components/EditRoomPage";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 
 export interface PeriodicSubRoomFormProps {
     roomUUID: string;

--- a/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/index.tsx
+++ b/desktop/renderer-app/src/pages/ModifyOrdinaryRoomPage/index.tsx
@@ -1,10 +1,10 @@
-import { observer } from "mobx-react-lite";
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { useParams } from "react-router-dom";
+import { useWindowSize } from "../../utils/hooks/use-window-size";
 import { RouteNameType, RouteParams } from "../../utils/routes";
 import { OrdinaryRoomForm } from "./OrdinaryRoomForm";
 import { PeriodicSubRoomForm } from "./PeriodicSubRoomForm";
-import { useWindowSize } from "../../utils/hooks/use-window-size";
 
 type ModifyOrdinaryRoomPageProps = {
     roomUUID: string;

--- a/desktop/renderer-app/src/pages/ModifyPeriodicRoomPage/index.tsx
+++ b/desktop/renderer-app/src/pages/ModifyPeriodicRoomPage/index.tsx
@@ -1,20 +1,20 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
-import { useHistory, useParams } from "react-router-dom";
+import { message } from "antd";
 import {
     EditRoomFormInitialValues,
     EditRoomFormValues,
+    LoadingPage,
     getEndTimeFromRate,
     getRateFromEndTime,
-    LoadingPage,
 } from "flat-components";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import EditRoomPage from "../../components/EditRoomPage";
-import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
+import { observer } from "mobx-react-lite";
+import { useHistory, useParams } from "react-router-dom";
 import { periodicRoomInfo, updatePeriodicRoom } from "../../api-middleware/flatServer";
+import EditRoomPage from "../../components/EditRoomPage";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
+import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
 
 type ModifyPeriodicRoomPageProps = {
     periodicUUID: string;

--- a/desktop/renderer-app/src/pages/OneToOnePage/OneToOneAvatar.tsx
+++ b/desktop/renderer-app/src/pages/OneToOnePage/OneToOneAvatar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { OneToOneVideoAvatar, OneToOneVideoAvatarProps } from "flat-components";
 import { AvatarCanvas } from "../../components/AvatarCanvas";
 import { User } from "../../stores/user-store";

--- a/desktop/renderer-app/src/pages/OneToOnePage/index.tsx
+++ b/desktop/renderer-app/src/pages/OneToOnePage/index.tsx
@@ -1,51 +1,49 @@
-import "./OneToOnePage.less";
-
 import React, { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
-import { observer } from "mobx-react-lite";
 import { message } from "antd";
-import { RoomPhase } from "white-web-sdk";
 import {
+    CloudRecordBtn,
+    LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
-    LoadingPage,
-    CloudRecordBtn,
-    Timer,
+    TopBarRightBtn,
 } from "flat-components";
-
-import InviteButton from "../../components/InviteButton";
-import { TopBarRightBtn } from "flat-components";
-import { RealtimePanel } from "../../components/RealtimePanel";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { RoomPhase } from "white-web-sdk";
+import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
+import { RtcChannelType } from "../../api-middleware/rtc";
+import exitSVG from "../../assets/image/exit.svg";
+import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import hideSideSVG from "../../assets/image/hide-side.svg";
+import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
+import shareScreenSVG from "../../assets/image/share-screen.svg";
+import { AppStoreButton } from "../../components/AppStoreButton";
 import { ChatPanel } from "../../components/ChatPanel";
-import { OneToOneAvatar } from "./OneToOneAvatar";
+import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
+import { CloudStorageButton } from "../../components/CloudStorageButton";
 import {
     ExitRoomConfirm,
     ExitRoomConfirmType,
     useExitRoomConfirmModal,
 } from "../../components/ExitRoomConfirm";
+import InviteButton from "../../components/InviteButton";
+import { RealtimePanel } from "../../components/RealtimePanel";
+import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
 import { Whiteboard } from "../../components/Whiteboard";
-import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RecordingConfig, useClassRoomStore } from "../../stores/class-room-store";
-import { RtcChannelType } from "../../api-middleware/rtc";
-import { useComputed } from "../../utils/mobx";
-import { RouteNameType, RouteParams } from "../../utils/routes";
+import { generateAvatar } from "../../utils/generate-avatar";
 import { usePowerSaveBlocker } from "../../utils/hooks/use-power-save-blocker";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { CloudStorageButton } from "../../components/CloudStorageButton";
-import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
+import { useComputed } from "../../utils/mobx";
+import { RouteNameType, RouteParams } from "../../utils/routes";
 import { runtime } from "../../utils/runtime";
-import { useTranslation } from "react-i18next";
-import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
-import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
-import shareScreenSVG from "../../assets/image/share-screen.svg";
-import exitSVG from "../../assets/image/exit.svg";
-import hideSideSVG from "../../assets/image/hide-side.svg";
-import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import { OneToOneAvatar } from "./OneToOneAvatar";
+import "./OneToOnePage.less";
 
 const recordingConfig: RecordingConfig = Object.freeze({
     channelType: RtcChannelType.Communication,

--- a/desktop/renderer-app/src/pages/PeriodicRoomDetailPage/index.tsx
+++ b/desktop/renderer-app/src/pages/PeriodicRoomDetailPage/index.tsx
@@ -1,20 +1,19 @@
-import "./index.less";
-
-import { clipboard } from "electron";
+import React, { useContext, useEffect, useState } from "react";
 import { message } from "antd";
+import { clipboard } from "electron";
+import { LoadingPage, MainPageHeader, PeriodicRoomPanel } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory, useParams } from "react-router-dom";
-import React, { useContext, useEffect, useState } from "react";
 import { useLastLocation } from "react-router-last-location";
-import { LoadingPage, MainPageHeader, PeriodicRoomPanel } from "flat-components";
+import { cancelPeriodicRoom, cancelPeriodicSubRoom } from "../../api-middleware/flatServer";
 import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
 import { RoomStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { globalStore } from "../../stores/global-store";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
 import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
-import { cancelPeriodicRoom, cancelPeriodicSubRoom } from "../../api-middleware/flatServer";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
+import "./index.less";
 
 /**
  * TODO: we forget set i18n in current file!!!

--- a/desktop/renderer-app/src/pages/ReplayPage/index.tsx
+++ b/desktop/renderer-app/src/pages/ReplayPage/index.tsx
@@ -1,23 +1,22 @@
 import React, { useEffect, useRef, useState } from "react";
-import { RouteComponentProps, useParams, useHistory } from "react-router-dom";
-import { ErrorPage, LoadingPage } from "flat-components";
 import PlayerController from "@netless/player-controller";
-import { ipcAsyncByMainWindow, ipcReceive, ipcReceiveRemove } from "../../utils/ipc";
-import { RealtimePanel } from "../../components/RealtimePanel";
-import { ChatPanelReplay } from "../../components/ChatPanelReplay";
+import { ErrorPage, LoadingPage } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { RouteComponentProps, useHistory, useParams } from "react-router-dom";
 import { OrdinaryRoomInfo } from "../../api-middleware/flatServer";
 import { RoomType } from "../../api-middleware/flatServer/constants";
-import { observer } from "mobx-react-lite";
-import { useClassRoomReplayStore } from "../../stores/class-room-replay-store";
-import { RouteNameType, RouteParams } from "../../utils/routes";
-
 import videoPlaySVG from "../../assets/image/video-play.svg";
-import "video.js/dist/video-js.min.css";
-import "@netless/window-manager/dist/style.css";
-import "./ReplayPage.less";
+import { ChatPanelReplay } from "../../components/ChatPanelReplay";
 import { ExitReplayConfirmModal } from "../../components/Modal/ExitReplayConfirmModal";
+import { RealtimePanel } from "../../components/RealtimePanel";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
+import { ipcAsyncByMainWindow, ipcReceive, ipcReceiveRemove } from "../../utils/ipc";
+import { RouteNameType, RouteParams } from "../../utils/routes";
+import "./ReplayPage.less";
+import "@netless/window-manager/dist/style.css";
+import "video.js/dist/video-js.min.css";
 
 export type ReplayPageProps = RouteComponentProps<{
     roomUUID: string;

--- a/desktop/renderer-app/src/pages/RoomDetailPage/index.tsx
+++ b/desktop/renderer-app/src/pages/RoomDetailPage/index.tsx
@@ -1,20 +1,19 @@
-import "./index.less";
-
 import React, { useContext, useEffect } from "react";
+import { message } from "antd";
 import { clipboard } from "electron";
 import { LoadingPage, MainPageHeader, RoomDetailPanel } from "flat-components";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { useHistory, useParams } from "react-router-dom";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
 import { GlobalStoreContext, RoomStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
 import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
 import { joinRoomHandler } from "../utils/join-room-handler";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
-import { message } from "antd";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 export const RoomDetailPage = observer<{}>(function RoomDetailPage() {
     useWindowSize("Main");

--- a/desktop/renderer-app/src/pages/SmallClassPage/SmallClassAvatar.tsx
+++ b/desktop/renderer-app/src/pages/SmallClassPage/SmallClassAvatar.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { SmallVideoAvatar, SmallVideoAvatarProps } from "flat-components";
-import { User } from "../../stores/user-store";
 import { AvatarCanvas } from "../../components/AvatarCanvas";
+import { User } from "../../stores/user-store";
 
 interface SmallClassAvatarProps extends Omit<SmallVideoAvatarProps, "avatarUser"> {
     rtcEngine: AgoraSDK;

--- a/desktop/renderer-app/src/pages/SmallClassPage/index.tsx
+++ b/desktop/renderer-app/src/pages/SmallClassPage/index.tsx
@@ -1,58 +1,54 @@
-import "./SmallClassPage.less";
-
 import React, { useEffect, useRef, useState } from "react";
 import { message } from "antd";
-import { RoomPhase } from "white-web-sdk";
-import { observer } from "mobx-react-lite";
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
 import {
+    CloudRecordBtn,
+    LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
-    LoadingPage,
-    CloudRecordBtn,
-    Timer,
+    TopBarRightBtn,
+    TopBarRoundBtn,
 } from "flat-components";
-
-import InviteButton from "../../components/InviteButton";
-import { TopBarRightBtn, TopBarRoundBtn } from "flat-components";
-import { RealtimePanel } from "../../components/RealtimePanel";
-import { ChatPanel } from "../../components/ChatPanel";
-import { SmallClassAvatar } from "./SmallClassAvatar";
-import { Whiteboard } from "../../components/Whiteboard";
-import ExitRoomConfirm, {
-    ExitRoomConfirmType,
-    useExitRoomConfirmModal,
-} from "../../components/ExitRoomConfirm";
-import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
-
-import { RtcChannelType } from "../../api-middleware/rtc";
-import { ClassModeType } from "../../api-middleware/rtm";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { RoomPhase } from "white-web-sdk";
 import {
     AgoraCloudRecordBackgroundConfigItem,
     AgoraCloudRecordLayoutConfigItem,
 } from "../../api-middleware/flatServer/agora";
-import { RecordingConfig, useClassRoomStore, User } from "../../stores/class-room-store";
-import { RouteNameType, RouteParams } from "../../utils/routes";
-import { usePowerSaveBlocker } from "../../utils/hooks/use-power-save-blocker";
-
-import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { CloudStorageButton } from "../../components/CloudStorageButton";
-import { runtime } from "../../utils/runtime";
-import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
-
-import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
-import shareScreenSVG from "../../assets/image/share-screen.svg";
-import exitSVG from "../../assets/image/exit.svg";
-import hideSideSVG from "../../assets/image/hide-side.svg";
-import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
+import { RtcChannelType } from "../../api-middleware/rtc";
+import { ClassModeType } from "../../api-middleware/rtm";
 import classInteractionSVG from "../../assets/image/class-interaction.svg";
 import classLectureSVG from "../../assets/image/class-lecture.svg";
+import exitSVG from "../../assets/image/exit.svg";
+import hideSideActiveSVG from "../../assets/image/hide-side-active.svg";
+import hideSideSVG from "../../assets/image/hide-side.svg";
+import shareScreenActiveSVG from "../../assets/image/share-screen-active.svg";
+import shareScreenSVG from "../../assets/image/share-screen.svg";
+import { AppStoreButton } from "../../components/AppStoreButton";
+import { ChatPanel } from "../../components/ChatPanel";
+import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
+import { CloudStorageButton } from "../../components/CloudStorageButton";
+import ExitRoomConfirm, {
+    ExitRoomConfirmType,
+    useExitRoomConfirmModal,
+} from "../../components/ExitRoomConfirm";
+import InviteButton from "../../components/InviteButton";
+import { RealtimePanel } from "../../components/RealtimePanel";
+import { ShareScreen, ShareScreenPicker } from "../../components/ShareScreen";
+import { Whiteboard } from "../../components/Whiteboard";
+import { RecordingConfig, User, useClassRoomStore } from "../../stores/class-room-store";
+import { generateAvatar } from "../../utils/generate-avatar";
+import { usePowerSaveBlocker } from "../../utils/hooks/use-power-save-blocker";
+import { useWindowSize } from "../../utils/hooks/use-window-size";
+import { RouteNameType, RouteParams } from "../../utils/routes";
+import { runtime } from "../../utils/runtime";
+import { SmallClassAvatar } from "./SmallClassAvatar";
+import "./SmallClassPage.less";
 
 const CLASSROOM_WIDTH = 1200;
 const AVATAR_AREA_WIDTH = CLASSROOM_WIDTH - 16 * 2;

--- a/desktop/renderer-app/src/pages/SplashPage/index.tsx
+++ b/desktop/renderer-app/src/pages/SplashPage/index.tsx
@@ -1,15 +1,14 @@
 import React, { useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import classNames from "classnames";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { loginCheck } from "../../api-middleware/flatServer";
-import { GlobalStoreContext } from "../../components/StoreProvider";
-import { RouteNameType, usePushHistory } from "../../utils/routes";
-
 import logoSVG from "../../assets/image/logo.svg";
-import "./SplashPage.less";
+import { GlobalStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { useTranslation } from "react-i18next";
+import { RouteNameType, usePushHistory } from "../../utils/routes";
+import "./SplashPage.less";
 
 enum LoginStatusType {
     Idle = "Idle",

--- a/desktop/renderer-app/src/pages/UserScheduledPage/index.tsx
+++ b/desktop/renderer-app/src/pages/UserScheduledPage/index.tsx
@@ -1,19 +1,19 @@
 import React, { useContext, useState } from "react";
+import { addMinutes, addWeeks, getDay, isBefore, roundToNearestMinutes } from "date-fns";
+import { EditRoomFormValues } from "flat-components";
 import { observer } from "mobx-react-lite";
-import { isBefore, addMinutes, roundToNearestMinutes, getDay, addWeeks } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import { RoomType } from "../../api-middleware/flatServer/constants";
+import EditRoomPage from "../../components/EditRoomPage";
 import {
     ConfigStoreContext,
     GlobalStoreContext,
     RoomStoreContext,
 } from "../../components/StoreProvider";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import EditRoomPage from "../../components/EditRoomPage";
-import { useHistory } from "react-router-dom";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { EditRoomFormValues } from "flat-components";
-import { useTranslation } from "react-i18next";
 
 const getInitialBeginTime = (): Date => {
     const now = new Date();

--- a/desktop/renderer-app/src/pages/UserSettingPage/AboutPage/index.tsx
+++ b/desktop/renderer-app/src/pages/UserSettingPage/AboutPage/index.tsx
@@ -1,15 +1,14 @@
-import logoSVG from "../icons/logo.svg";
-import updateSVG from "../icons/update.svg";
-import "./style.less";
-
 import React, { useState } from "react";
-import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
 import { Button, message } from "antd";
-import { runtime } from "../../../utils/runtime";
-import { ipcSyncByApp } from "../../../utils/ipc";
+import { useTranslation } from "react-i18next";
 import { AppUpgradeModal, AppUpgradeModalProps } from "../../../components/AppUpgradeModal";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { useTranslation } from "react-i18next";
+import { ipcSyncByApp } from "../../../utils/ipc";
+import { runtime } from "../../../utils/runtime";
+import logoSVG from "../icons/logo.svg";
+import updateSVG from "../icons/update.svg";
+import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import "./style.less";
 
 export const AboutPage = (): React.ReactElement => {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/UserSettingPage/GeneralSettingPage/index.tsx
+++ b/desktop/renderer-app/src/pages/UserSettingPage/GeneralSettingPage/index.tsx
@@ -1,11 +1,10 @@
-import "./style.less";
-
-import { Checkbox, Radio } from "antd";
-import type { CheckboxChangeEvent } from "antd/lib/checkbox";
 import React, { useEffect, useState } from "react";
-import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
-import { ipcSyncByApp, ipcAsyncByApp } from "../../../utils/ipc";
+import { Checkbox, Radio } from "antd";
+import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { useTranslation } from "react-i18next";
+import { ipcAsyncByApp, ipcSyncByApp } from "../../../utils/ipc";
+import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import "./style.less";
 
 enum SelectLanguage {
     Chinese,

--- a/desktop/renderer-app/src/pages/UserSettingPage/HotKeySettingPage/index.tsx
+++ b/desktop/renderer-app/src/pages/UserSettingPage/HotKeySettingPage/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
-import { Table } from "antd";
 import React from "react";
-import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import { Table } from "antd";
 import { useTranslation } from "react-i18next";
+import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import "./style.less";
 
 interface HotKeyTable {
     name: string;

--- a/desktop/renderer-app/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
+++ b/desktop/renderer-app/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
@@ -1,14 +1,13 @@
 /* eslint react/display-name: off */
-import generalSVG from "./icons/general.svg";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
+import { RouteNameType, routeConfig } from "../../route-config";
+import { useWindowSize } from "../../utils/hooks/use-window-size";
 import aboutSVG from "./icons/about.svg";
+import generalSVG from "./icons/general.svg";
 import hotkeySVG from "./icons/hotkey.svg";
 import "./UserSettingLayoutContainer.less";
-
-import React from "react";
-import { MainPageLayoutContainer } from "../../components/MainPageLayoutContainer";
-import { useWindowSize } from "../../utils/hooks/use-window-size";
-import { routeConfig, RouteNameType } from "../../route-config";
-import { useTranslation } from "react-i18next";
 
 export const UserSettingLayoutContainer: React.FC = ({ children }): React.ReactElement => {
     const { t } = useTranslation();

--- a/desktop/renderer-app/src/pages/utils/join-room-handler.ts
+++ b/desktop/renderer-app/src/pages/utils/join-room-handler.ts
@@ -1,8 +1,8 @@
-import { RouteNameType, usePushHistory } from "../../utils/routes";
-import { roomStore } from "../../stores/room-store";
 import { RoomType } from "../../api-middleware/flatServer/constants";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { globalStore } from "../../stores/global-store";
+import { roomStore } from "../../stores/room-store";
+import { RouteNameType, usePushHistory } from "../../utils/routes";
 
 export const joinRoomHandler = async (
     roomUUID: string,

--- a/desktop/renderer-app/src/route-config.ts
+++ b/desktop/renderer-app/src/route-config.ts
@@ -1,25 +1,25 @@
 import { ComponentType } from "react";
-import SplashPage from "./pages/SplashPage";
-import LoginPage from "./pages/LoginPage";
-import BigClassPage from "./pages/BigClassPage";
-import SmallClassPage from "./pages/SmallClassPage";
-import OneToOnePage from "./pages/OneToOnePage";
-import ReplayPage from "./pages/ReplayPage";
-import RoomDetailPage from "./pages/RoomDetailPage";
-import HomePage from "./pages/HomePage";
-import UserScheduledPage from "./pages/UserScheduledPage";
-import { ModifyOrdinaryRoomPage } from "./pages/ModifyOrdinaryRoomPage";
-import { ModifyPeriodicRoomPage } from "./pages/ModifyPeriodicRoomPage";
 import { RoomType } from "./api-middleware/flatServer/constants";
+import BigClassPage from "./pages/BigClassPage";
 import { CloudStoragePage } from "./pages/CloudStoragePage";
 import { CameraCheckPage } from "./pages/DeviceCheckPages/CameraCheckPage";
 import { MicrophoneCheckPage } from "./pages/DeviceCheckPages/MicrophoneCheckPage";
 import { SpeakerCheckPage } from "./pages/DeviceCheckPages/SpeakerCheckPage";
 import { SystemCheckPage } from "./pages/DeviceCheckPages/SystemCheckPage";
+import HomePage from "./pages/HomePage";
+import LoginPage from "./pages/LoginPage";
+import { ModifyOrdinaryRoomPage } from "./pages/ModifyOrdinaryRoomPage";
+import { ModifyPeriodicRoomPage } from "./pages/ModifyPeriodicRoomPage";
+import OneToOnePage from "./pages/OneToOnePage";
+import { PeriodicRoomDetailPage } from "./pages/PeriodicRoomDetailPage";
+import ReplayPage from "./pages/ReplayPage";
+import RoomDetailPage from "./pages/RoomDetailPage";
+import SmallClassPage from "./pages/SmallClassPage";
+import SplashPage from "./pages/SplashPage";
+import UserScheduledPage from "./pages/UserScheduledPage";
+import { AboutPage } from "./pages/UserSettingPage/AboutPage";
 import { GeneralSettingPage } from "./pages/UserSettingPage/GeneralSettingPage";
 import { HotKeySettingPage } from "./pages/UserSettingPage/HotKeySettingPage";
-import { AboutPage } from "./pages/UserSettingPage/AboutPage";
-import { PeriodicRoomDetailPage } from "./pages/PeriodicRoomDetailPage";
 
 export enum RouteNameType {
     SplashPage = "SplashPage",

--- a/desktop/renderer-app/src/stores/class-room-replay-store.ts
+++ b/desktop/renderer-app/src/stores/class-room-replay-store.ts
@@ -1,16 +1,16 @@
 import { useState } from "react";
-import { makeAutoObservable, observable, runInAction } from "mobx";
 import dateAdd from "date-fns/add";
+import { makeAutoObservable, observable, runInAction } from "mobx";
+import { RoomType } from "../api-middleware/flatServer/constants";
 import { Rtm as RTMAPI, RTMessageType } from "../api-middleware/rtm";
 import { SmartPlayer, SmartPlayerEventType } from "../api-middleware/smart-player";
+import { NODE_ENV } from "../constants/process";
+import { ipcAsyncByMainWindow } from "../utils/ipc";
+import { useAutoRun } from "../utils/mobx";
+import { RTMChannelMessage } from "./class-room-store";
 import { globalStore } from "./global-store";
 import { RoomItem, roomStore } from "./room-store";
-import { NODE_ENV } from "../constants/process";
-import { useAutoRun } from "../utils/mobx";
-import { RoomType } from "../api-middleware/flatServer/constants";
-import { ipcAsyncByMainWindow } from "../utils/ipc";
 import { UserStore } from "./user-store";
-import { RTMChannelMessage } from "./class-room-store";
 
 export class ClassRoomReplayStore {
     public readonly roomUUID: string;

--- a/desktop/renderer-app/src/stores/class-room-store.ts
+++ b/desktop/renderer-app/src/stores/class-room-store.ts
@@ -1,21 +1,10 @@
 import { useEffect, useState } from "react";
+import { AgoraNetworkQuality, RtcStats } from "agora-electron-sdk/types/Api/native_type";
+import dateSub from "date-fns/sub";
+import { i18n } from "i18next";
 import { action, autorun, makeAutoObservable, observable, reaction, runInAction } from "mobx";
 import { v4 as uuidv4 } from "uuid";
-import dateSub from "date-fns/sub";
-import { Rtc as RTCAPI, RtcChannelType } from "../api-middleware/rtc";
-import {
-    ClassModeType,
-    NonDefaultUserProp,
-    Rtm as RTMAPI,
-    RTMessage,
-    RTMessageType,
-    RTMEvents,
-} from "../api-middleware/rtm";
 import { CloudRecording } from "../api-middleware/cloud-recording";
-import {
-    CloudRecordStartPayload,
-    CloudRecordUpdateLayoutPayload,
-} from "../api-middleware/flatServer/agora";
 import {
     pauseClass,
     startClass,
@@ -23,20 +12,31 @@ import {
     stopClass,
     stopRecordRoom,
 } from "../api-middleware/flatServer";
+import {
+    CloudRecordStartPayload,
+    CloudRecordUpdateLayoutPayload,
+} from "../api-middleware/flatServer/agora";
 import { RoomStatus, RoomType } from "../api-middleware/flatServer/constants";
-import { RoomItem, roomStore } from "./room-store";
-import { globalStore } from "./global-store";
-import { NODE_ENV } from "../constants/process";
-import { useAutoRun } from "../utils/mobx";
-import { User, UserStore } from "./user-store";
-import { ipcAsyncByMainWindow } from "../utils/ipc";
-import type { AgoraNetworkQuality, RtcStats } from "agora-electron-sdk/types/Api/native_type";
+import { Rtc as RTCAPI, RtcChannelType } from "../api-middleware/rtc";
+import {
+    ClassModeType,
+    NonDefaultUserProp,
+    Rtm as RTMAPI,
+    RTMEvents,
+    RTMessage,
+    RTMessageType,
+} from "../api-middleware/rtm";
 import { errorTips } from "../components/Tips/ErrorTips";
-import { WhiteboardStore } from "./whiteboard-store";
-import { RouteNameType, usePushHistory } from "../utils/routes";
+import { NODE_ENV } from "../constants/process";
 import { useSafePromise } from "../utils/hooks/lifecycle";
+import { ipcAsyncByMainWindow } from "../utils/ipc";
+import { useAutoRun } from "../utils/mobx";
+import { RouteNameType, usePushHistory } from "../utils/routes";
+import { globalStore } from "./global-store";
+import { RoomItem, roomStore } from "./room-store";
 import { ShareScreenStore } from "./share-screen-store";
-import { i18n } from "i18next";
+import { User, UserStore } from "./user-store";
+import { WhiteboardStore } from "./whiteboard-store";
 
 export type { User } from "./user-store";
 

--- a/desktop/renderer-app/src/stores/global-store.ts
+++ b/desktop/renderer-app/src/stores/global-store.ts
@@ -1,6 +1,6 @@
 import { Region } from "flat-components";
-import { autoPersistStore } from "./utils";
 import { LoginProcessResult } from "../api-middleware/flatServer";
+import { autoPersistStore } from "./utils";
 
 // clear storage if not match
 const LS_VERSION = 1;

--- a/desktop/renderer-app/src/stores/room-store.ts
+++ b/desktop/renderer-app/src/stores/room-store.ts
@@ -1,28 +1,28 @@
 /* eslint no-redeclare: off */
-import { makeAutoObservable, observable, runInAction } from "mobx";
 import { Region } from "flat-components";
+import { makeAutoObservable, observable, runInAction } from "mobx";
 import {
-    cancelRoom,
     CancelRoomPayload,
-    createOrdinaryRoom,
     CreateOrdinaryRoomPayload,
-    createPeriodicRoom,
     CreatePeriodicRoomPayload,
-    joinRoom,
     JoinRoomResult,
-    listRooms,
     ListRoomsPayload,
     ListRoomsType,
+    PeriodicRoomInfoResult,
+    PeriodicSubRoomInfoPayload,
+    cancelRoom,
+    createOrdinaryRoom,
+    createPeriodicRoom,
+    joinRoom,
+    listRooms,
     ordinaryRoomInfo,
     periodicRoomInfo,
-    PeriodicRoomInfoResult,
     periodicSubRoomInfo,
-    PeriodicSubRoomInfoPayload,
     recordInfo,
 } from "../api-middleware/flatServer";
 import { RoomStatus, RoomType } from "../api-middleware/flatServer/constants";
-import { globalStore } from "./global-store";
 import { configStore } from "./config-store";
+import { globalStore } from "./global-store";
 
 // Sometime we may only have pieces of the room info
 /** Ordinary room + periodic sub-room */

--- a/desktop/renderer-app/src/stores/share-screen-store/listener-other-user-share-screen.ts
+++ b/desktop/renderer-app/src/stores/share-screen-store/listener-other-user-share-screen.ts
@@ -1,4 +1,4 @@
-import type AgoraSDK from "agora-electron-sdk";
+import AgoraSDK from "agora-electron-sdk";
 import { globalStore } from "../global-store";
 
 export class ListenerOtherUserShareScreen {

--- a/desktop/renderer-app/src/stores/user-store.ts
+++ b/desktop/renderer-app/src/stores/user-store.ts
@@ -1,6 +1,6 @@
 import { action, makeAutoObservable, observable } from "mobx";
-import { CloudRecordStartPayload } from "../api-middleware/flatServer/agora";
 import { usersInfo } from "../api-middleware/flatServer";
+import { CloudRecordStartPayload } from "../api-middleware/flatServer/agora";
 import { configStore } from "./config-store";
 
 export interface User {

--- a/desktop/renderer-app/src/stores/whiteboard-store.ts
+++ b/desktop/renderer-app/src/stores/whiteboard-store.ts
@@ -1,13 +1,11 @@
-import "video.js/dist/video-js.css";
-
-import type { Attributes as SlideAttributes } from "@netless/app-slide";
+import { Attributes as SlideAttributes } from "@netless/app-slide";
 import { AddAppParams, BuiltinApps, WindowManager } from "@netless/window-manager";
 import { message } from "antd";
 import { i18n } from "i18next";
-import { v4 as v4uuid } from "uuid";
 import { debounce } from "lodash-es";
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { isMobile, isWindows } from "react-device-detect";
+import { v4 as v4uuid } from "uuid";
 import {
     DefaultHotKeys,
     DeviceType,
@@ -19,15 +17,16 @@ import {
     WhiteWebSdk,
 } from "white-web-sdk";
 import { RoomType } from "../../../../packages/flat-components/src/types/room";
+import { queryConvertingTaskStatus } from "../api-middleware/courseware-converting";
+import { convertFinish } from "../api-middleware/flatServer/storage";
+import { RequestErrorCode } from "../constants/error-code";
 import { CLOUD_STORAGE_DOMAIN, NETLESS, NODE_ENV } from "../constants/process";
 import { CloudStorageFile, CloudStorageStore } from "../pages/CloudStoragePage/store";
 import { getCoursewarePreloader } from "../utils/courseware-preloader";
-import { globalStore } from "./global-store";
-import { getFileExt, isPPTX } from "../utils/file";
-import { queryConvertingTaskStatus } from "../api-middleware/courseware-converting";
-import { convertFinish } from "../api-middleware/flatServer/storage";
 import { ServerRequestError } from "../utils/error/server-request-error";
-import { RequestErrorCode } from "../constants/error-code";
+import { getFileExt, isPPTX } from "../utils/file";
+import { globalStore } from "./global-store";
+import "video.js/dist/video-js.css";
 
 export class WhiteboardStore {
     public room: Room | null = null;

--- a/desktop/renderer-app/src/tasks/index.ts
+++ b/desktop/renderer-app/src/tasks/index.ts
@@ -1,9 +1,9 @@
 import { initEnv } from "./init-env";
 import { initRegisterApps } from "./init-register-apps";
-import { initWhiteSDK } from "./init-white-sdk";
 import { initUI } from "./init-ui";
 import { initURLProtocol } from "./init-url-protocol";
 import { initWaitRTC } from "./init-wait-rtc";
+import { initWhiteSDK } from "./init-white-sdk";
 
 const tasks = [initEnv, initURLProtocol, initWhiteSDK, initWaitRTC, initUI, initRegisterApps];
 

--- a/desktop/renderer-app/src/tasks/init-env.ts
+++ b/desktop/renderer-app/src/tasks/init-env.ts
@@ -1,5 +1,5 @@
-import { runtime } from "../utils/runtime";
 import { ipcSyncByApp } from "../utils/ipc";
+import { runtime } from "../utils/runtime";
 
 export const initEnv = async (): Promise<void> => {
     const runtimeKeys = Object.keys(runtime);

--- a/desktop/renderer-app/src/tasks/init-register-apps.ts
+++ b/desktop/renderer-app/src/tasks/init-register-apps.ts
@@ -1,6 +1,6 @@
-import { WindowManager } from "@netless/window-manager";
-import { addHooks as addHooksSlide } from "@netless/app-slide";
 import path from "path";
+import { addHooks as addHooksSlide } from "@netless/app-slide";
+import { WindowManager } from "@netless/window-manager";
 
 const registerApps = (): void => {
     void WindowManager.register({

--- a/desktop/renderer-app/src/tasks/init-ui.tsx
+++ b/desktop/renderer-app/src/tasks/init-ui.tsx
@@ -1,22 +1,18 @@
-import "flat-components/theme/index.less";
-import "../theme.less";
-
+import React, { useEffect, useMemo } from "react";
 import { ConfigProvider } from "antd";
 import enUS from "antd/lib/locale/en_US";
 import zhCN from "antd/lib/locale/zh_CN";
-
-import React, { useEffect, useMemo } from "react";
+import { configure } from "mobx";
 import ReactDOM from "react-dom";
-
 import { I18nextProvider } from "react-i18next";
 import { useUpdate } from "react-use";
-
-import { i18n } from "../utils/i18n";
 import { AppRoutes } from "../AppRoutes";
 import { StoreProvider } from "../components/StoreProvider";
+import { i18n } from "../utils/i18n";
+import "flat-components/theme/index.less";
+// eslint-disable-next-line import/order
+import "../theme.less";
 
-/** configure right after import */
-import { configure } from "mobx";
 configure({
     isolateGlobalState: true,
 });

--- a/desktop/renderer-app/src/tasks/init-url-protocol.ts
+++ b/desktop/renderer-app/src/tasks/init-url-protocol.ts
@@ -1,6 +1,6 @@
-import { ipcReceive } from "../utils/ipc";
 import { configure } from "mobx";
 import { urlProtocolStore } from "../stores/url-protocol-store";
+import { ipcReceive } from "../utils/ipc";
 
 configure({
     isolateGlobalState: true,

--- a/desktop/renderer-app/src/tasks/init-white-sdk.ts
+++ b/desktop/renderer-app/src/tasks/init-white-sdk.ts
@@ -1,4 +1,4 @@
-import { injectCustomStyle, CursorNames } from "white-web-sdk";
+import { CursorNames, injectCustomStyle } from "white-web-sdk";
 
 // https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
 // https://yoksel.github.io/url-encoder

--- a/desktop/renderer-app/src/utils/courseware-preloader.ts
+++ b/desktop/renderer-app/src/utils/courseware-preloader.ts
@@ -1,5 +1,5 @@
-import { copy, ensureDir, remove, pathExists } from "fs-extra";
 import path from "path";
+import { copy, ensureDir, pathExists, remove } from "fs-extra";
 import { DownloaderHelper } from "node-downloader-helper";
 import { runtime } from "./runtime";
 import { extractZIP } from "./unzip";

--- a/desktop/renderer-app/src/utils/drag-and-drop/image.ts
+++ b/desktop/renderer-app/src/utils/drag-and-drop/image.ts
@@ -1,6 +1,6 @@
 import { message } from "antd";
 import { v4 as v4uuid } from "uuid";
-import type { Room, Size } from "white-web-sdk";
+import { Room, Size } from "white-web-sdk";
 import { listFiles } from "../../api-middleware/flatServer/storage";
 import { i18n } from "../i18n";
 import { UploadTask } from "../upload-task-manager/upload-task";

--- a/desktop/renderer-app/src/utils/error/server-request-error.ts
+++ b/desktop/renderer-app/src/utils/error/server-request-error.ts
@@ -1,5 +1,5 @@
-import { RequestError } from "./request-error";
 import { RequestErrorCode, RequestErrorMessage } from "../../constants/error-code";
+import { RequestError } from "./request-error";
 
 export class ServerRequestError extends RequestError {
     public errorCode: RequestErrorCode;

--- a/desktop/renderer-app/src/utils/hooks/use-rtc-engine.ts
+++ b/desktop/renderer-app/src/utils/hooks/use-rtc-engine.ts
@@ -1,4 +1,4 @@
-import type AgoraSdk from "agora-electron-sdk";
+import AgoraSdk from "agora-electron-sdk";
 
 export function useRTCEngine(): AgoraSdk {
     return window.rtcEngine;

--- a/desktop/renderer-app/src/utils/hooks/use-url-app-launcher.ts
+++ b/desktop/renderer-app/src/utils/hooks/use-url-app-launcher.ts
@@ -1,10 +1,10 @@
 import { useContext } from "react";
+import { matchPath, useLocation } from "react-router-dom";
 import { GlobalStoreContext, URLProtocolStoreContext } from "../../components/StoreProvider";
 import { joinRoomHandler } from "../../pages/utils/join-room-handler";
-import { useAutoRun } from "../mobx";
-import { usePushHistory, RouteNameType, RouteParams } from "../routes";
-import { matchPath, useLocation } from "react-router-dom";
 import { ClassRouteName, routeConfig } from "../../route-config";
+import { useAutoRun } from "../mobx";
+import { RouteNameType, RouteParams, usePushHistory } from "../routes";
 
 /**
  * Listen to UrlProtocolStore toJoinRoomUUID value that to join room.

--- a/desktop/renderer-app/src/utils/ipc.ts
+++ b/desktop/renderer-app/src/utils/ipc.ts
@@ -1,6 +1,5 @@
-import { ipc } from "flat-types";
 import { ipcRenderer } from "electron";
-import { constants } from "flat-types";
+import { constants, ipc } from "flat-types";
 
 export const ipcAsyncByMainWindow = <
     T extends keyof ipc.WindowActionAsync,

--- a/desktop/renderer-app/src/utils/mobx.ts
+++ b/desktop/renderer-app/src/utils/mobx.ts
@@ -1,18 +1,18 @@
+import { DependencyList, useEffect, useMemo, useRef } from "react";
 import {
-    autorun,
     IAutorunOptions,
+    IComputedValue,
+    IComputedValueOptions,
     IReactionOptions,
     IReactionPublic,
     IWhenOptions,
+    autorun,
+    computed,
+    observable,
     reaction,
     when,
-    computed,
-    IComputedValueOptions,
-    IComputedValue,
-    observable,
 } from "mobx";
 import { useLocalObservable } from "mobx-react-lite";
-import { useEffect, DependencyList, useMemo, useRef } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 
 /**

--- a/desktop/renderer-app/src/utils/routes.ts
+++ b/desktop/renderer-app/src/utils/routes.ts
@@ -1,6 +1,6 @@
-import { routeConfig, RouteConfig, RouteNameType, ExtraRouteConfig } from "../route-config";
-import { generatePath, useHistory } from "react-router-dom";
 import { useCallback } from "react";
+import { generatePath, useHistory } from "react-router-dom";
+import { ExtraRouteConfig, RouteConfig, RouteNameType, routeConfig } from "../route-config";
 
 export { RouteNameType } from "../route-config";
 

--- a/desktop/renderer-app/src/utils/unzip.ts
+++ b/desktop/renderer-app/src/utils/unzip.ts
@@ -1,5 +1,5 @@
-import extract from "extract-zip";
 import path from "path";
+import extract from "extract-zip";
 
 /**
  * unzip zip file

--- a/desktop/renderer-app/src/utils/upload-task-manager/index.ts
+++ b/desktop/renderer-app/src/utils/upload-task-manager/index.ts
@@ -1,7 +1,7 @@
+import { UploadID } from "flat-components";
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { cancelUpload } from "../../api-middleware/flatServer/storage";
 import { UploadStatusType, UploadTask } from "./upload-task";
-import { UploadID } from "flat-components";
 
 export enum UploadTaskManagerStatusType {
     Idle = 1,

--- a/desktop/renderer-app/src/utils/upload-task-manager/upload-task.ts
+++ b/desktop/renderer-app/src/utils/upload-task-manager/upload-task.ts
@@ -1,16 +1,16 @@
+import Axios, { CancelTokenSource } from "axios";
 import { makeAutoObservable, observable } from "mobx";
 import { v4 as v4uuid } from "uuid";
-import Axios, { CancelTokenSource } from "axios";
 import {
+    UploadStartResult,
     cancelUpload,
     uploadFinish,
     uploadStart,
-    UploadStartResult,
 } from "../../api-middleware/flatServer/storage";
-import { CLOUD_STORAGE_OSS_ALIBABA_CONFIG } from "../../constants/process";
-import { ServerRequestError } from "../error/server-request-error";
 import { RequestErrorCode } from "../../constants/error-code";
+import { CLOUD_STORAGE_OSS_ALIBABA_CONFIG } from "../../constants/process";
 import { configStore } from "../../stores/config-store";
+import { ServerRequestError } from "../error/server-request-error";
 
 export enum UploadStatusType {
     Pending = 1,

--- a/desktop/renderer-app/vite.config.ts
+++ b/desktop/renderer-app/vite.config.ts
@@ -1,21 +1,20 @@
+import path from "path";
 import refresh from "@vitejs/plugin-react-refresh";
+import copy from "rollup-plugin-copy";
+import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import eslintPlugin from "vite-plugin-eslint";
-import { visualizer } from "rollup-plugin-visualizer";
-import copy from "rollup-plugin-copy";
-import path from "path";
-
 // TODO: find new place to store vite-plugin-dotenv
+import {
+    componentsEntryPath,
+    configPath,
+    i18nEntryPath,
+    rendererPath,
+    rootNodeModules,
+    typesEntryPath,
+} from "../../scripts/constants";
 import { dotenv } from "../../web/flat-web/scripts/vite-plugin-dotenv";
 import { electron } from "./scripts/vite-plugin-electron";
-import {
-    configPath,
-    typesEntryPath,
-    i18nEntryPath,
-    componentsEntryPath,
-    rootNodeModules,
-    rendererPath,
-} from "../../scripts/constants";
 
 export default defineConfig(() => {
     const plugins = [

--- a/packages/flat-components/package.json
+++ b/packages/flat-components/package.json
@@ -60,6 +60,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-app": "^6.2.2",

--- a/packages/flat-components/src/components/ChatPanel/ChatMessage/ChatMessage.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessage/ChatMessage.stories.tsx
@@ -1,9 +1,9 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-import React from "react";
-import { ChatMessage, ChatMessageProps } from ".";
 import { ChatMsgType } from "../types";
+import { ChatMessage, ChatMessageProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/ChatPanel/ChatMessage/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessage/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React, { useEffect } from "react";
 import { observer } from "mobx-react-lite";
-import { ChatMsg, ChatMsgType } from "../types";
 import { useTranslation } from "react-i18next";
+import { ChatMsg, ChatMsgType } from "../types";
+import "./style.less";
 
 export interface ChatMessageProps {
     /** current user uuid */

--- a/packages/flat-components/src/components/ChatPanel/ChatMessageList/ChatMessageList.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessageList/ChatMessageList.stories.tsx
@@ -1,10 +1,10 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-import React from "react";
-import { ChatMessageList, ChatMessageListProps } from ".";
 import { User } from "../../../types/user";
 import { ChatMsgType } from "../types";
+import { ChatMessageList, ChatMessageListProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/ChatPanel/ChatMessageList/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessageList/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useUpdate } from "react-use";
 import { Observer, observer } from "mobx-react-lite";
+import { useUpdate } from "react-use";
 import {
     AutoSizer,
     CellMeasurer,

--- a/packages/flat-components/src/components/ChatPanel/ChatMessages/ChatMessages.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessages/ChatMessages.stories.tsx
@@ -1,10 +1,10 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-import React from "react";
-import { ChatMessages, ChatMessagesProps } from ".";
 import { User } from "../../../types/user";
 import { ChatMsgType } from "../types";
+import { ChatMessages, ChatMessagesProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/ChatPanel/ChatMessages/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessages/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
-
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { ChatTypeBox, ChatTypeBoxProps } from "../ChatTypeBox";
-import { ChatMessageList, ChatMessageListProps } from "../ChatMessageList";
 import { useTranslation } from "react-i18next";
+import { ChatMessageList, ChatMessageListProps } from "../ChatMessageList";
+import { ChatTypeBox, ChatTypeBoxProps } from "../ChatTypeBox";
+import "./style.less";
 
 export type ChatMessagesProps = ChatTypeBoxProps & ChatMessageListProps;
 

--- a/packages/flat-components/src/components/ChatPanel/ChatPanel.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatPanel.stories.tsx
@@ -1,10 +1,10 @@
-import { Meta, Story } from "@storybook/react";
-import faker from "faker";
-import Chance from "chance";
 import React from "react";
-import { ChatPanel, ChatPanelProps } from ".";
+import { Meta, Story } from "@storybook/react";
+import Chance from "chance";
+import faker from "faker";
 import { User } from "../../types/user";
 import { ChatMsgType } from "./types";
+import { ChatPanel, ChatPanelProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/ChatPanel/ChatTabTitle/ChatTabTitle.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTabTitle/ChatTabTitle.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { ChatTabTitle, ChatTabTitleProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ChatPanel/ChatTabTitle/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTabTitle/index.tsx
@@ -1,7 +1,6 @@
-import "./style.less";
-
 import React, { FC, useMemo } from "react";
 import classNames from "classnames";
+import "./style.less";
 
 export interface ChatTabTitleProps {
     unreadCount?: number | null;

--- a/packages/flat-components/src/components/ChatPanel/ChatTypeBox/ChatTypeBox.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTypeBox/ChatTypeBox.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { ChatTypeBox, ChatTypeBoxProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ChatPanel/ChatTypeBox/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTypeBox/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
-import sendSVG from "./icons/send.svg";
-import banChatSVG from "./icons/ban-chat.svg";
-import banChatActiveSVG from "./icons/ban-chat-active.svg";
-
 import React, { useMemo, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { useSafePromise } from "../../../utils/hooks";
 import { useTranslation } from "react-i18next";
+import { useSafePromise } from "../../../utils/hooks";
+import banChatActiveSVG from "./icons/ban-chat-active.svg";
+import banChatSVG from "./icons/ban-chat.svg";
+import sendSVG from "./icons/send.svg";
+import "./style.less";
 
 export interface ChatTypeBoxProps {
     /** Only room owner can ban chatting. */

--- a/packages/flat-components/src/components/ChatPanel/ChatUser/ChatUser.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUser/ChatUser.stories.tsx
@@ -1,8 +1,8 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
-import { ChatUser, ChatUserProps } from ".";
 import { User } from "../../../types/user";
+import { ChatUser, ChatUserProps } from ".";
 
 const storyMeta: Meta = {
     title: "ChatPanel/ChatUser",

--- a/packages/flat-components/src/components/ChatPanel/ChatUser/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUser/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
-import { User } from "../../../types/user";
 import { useTranslation } from "react-i18next";
+import { User } from "../../../types/user";
+import "./style.less";
 
 export interface ChatUserProps {
     /** room owner uuid */

--- a/packages/flat-components/src/components/ChatPanel/ChatUsers/ChatUsers.stories.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUsers/ChatUsers.stories.tsx
@@ -1,9 +1,9 @@
-import { Meta, Story } from "@storybook/react";
-import faker from "faker";
-import Chance from "chance";
 import React from "react";
-import { ChatUsers, ChatUsersProps } from ".";
+import { Meta, Story } from "@storybook/react";
+import Chance from "chance";
+import faker from "faker";
 import { User } from "../../../types/user";
+import { ChatUsers, ChatUsersProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/ChatPanel/ChatUsers/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatUsers/index.tsx
@@ -1,13 +1,12 @@
-import "./style.less";
-import noHandSVG from "./icons/no-hand.svg";
-
 import React from "react";
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
-import { AutoSizer, List, ListRowRenderer, Size } from "react-virtualized";
-import { ChatUser, ChatUserProps } from "../ChatUser";
-import { User } from "../../../types/user";
 import { useTranslation } from "react-i18next";
+import { AutoSizer, List, ListRowRenderer, Size } from "react-virtualized";
+import { User } from "../../../types/user";
+import { ChatUser, ChatUserProps } from "../ChatUser";
+import noHandSVG from "./icons/no-hand.svg";
+import "./style.less";
 
 export type ChatUsersProps = {
     isCreator: boolean;

--- a/packages/flat-components/src/components/ChatPanel/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
-
 import React, { useState } from "react";
 import { Tabs } from "antd";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { ChatMessages, ChatMessagesProps } from "./ChatMessages";
 import { ChatTabTitle, ChatTabTitleProps } from "./ChatTabTitle";
 import { ChatUsers, ChatUsersProps } from "./ChatUsers";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export type ChatPanelProps = ChatTabTitleProps &
     Omit<ChatMessagesProps, "visible"> &

--- a/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/BigVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/BigVideoAvatar.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { BigVideoAvatar, BigVideoAvatarProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/BigVideoAvatar/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
 import React from "react";
-import { VideoAvatarProps, VideoAvatar } from "../VideoAvatar";
 import classNames from "classnames";
+import { VideoAvatar, VideoAvatarProps } from "../VideoAvatar";
+import "./style.less";
 
 export type BigVideoAvatarProps = VideoAvatarProps;
 

--- a/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/cloudrecord.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/cloudrecord.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
+import { Meta, Story } from "@storybook/react";
 import { CloudRecordBtn, CloudRecordBtnProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/index.tsx
@@ -1,9 +1,9 @@
-import { TopBarRightBtn } from "../";
-import { observer } from "mobx-react-lite";
 import React from "react";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { TopBarRightBtn } from "../";
 import RecordIdleSVG from "./icons/record-idle.svg";
 import RecordStartedSVG from "./icons/record-started.svg";
-import { useTranslation } from "react-i18next";
 
 export type CloudRecordBtnProps = {
     isRecording: boolean;

--- a/packages/flat-components/src/components/ClassroomPage/ExitRoomConfirmModal/ExitRoomConfirmModal.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/ExitRoomConfirmModal/ExitRoomConfirmModal.stories.tsx
@@ -1,12 +1,12 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import {
     CloseRoomConfirmModal,
     CloseRoomConfirmModalProps,
-    StopClassConfirmModal,
-    StopClassConfirmModalProps,
     ExitRoomConfirmModal,
     ExitRoomConfirmModalProps,
+    StopClassConfirmModal,
+    StopClassConfirmModalProps,
 } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/NetworkStatus/NetworkStatus.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/NetworkStatus/NetworkStatus.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { NetworkStatus, NetworkStatusProps } from ".";
+import { Meta, Story } from "@storybook/react";
 import faker from "faker";
+import { NetworkStatus, NetworkStatusProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/NetworkStatus",

--- a/packages/flat-components/src/components/ClassroomPage/NetworkStatus/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/NetworkStatus/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
+import React, { useMemo } from "react";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import signal0SVG from "./icons/signal-0.svg";
 import signal1SVG from "./icons/signal-1.svg";
 import signal2SVG from "./icons/signal-2.svg";
 import signal3SVG from "./icons/signal-3.svg";
-
-import React, { useMemo } from "react";
-import { observer } from "mobx-react-lite";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 interface NetworkQuality {
     delay: number;

--- a/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/OneToOneVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/OneToOneVideoAvatar.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { OneToOneVideoAvatar, OneToOneVideoAvatarProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/OneToOneVideoAvatar/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
 import React from "react";
-import { VideoAvatar, VideoAvatarProps } from "../VideoAvatar";
 import classNames from "classnames";
+import { VideoAvatar, VideoAvatarProps } from "../VideoAvatar";
+import "./style.less";
 
 export type OneToOneVideoAvatarProps = VideoAvatarProps;
 

--- a/packages/flat-components/src/components/ClassroomPage/RaiseHand/RaiseHand.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RaiseHand/RaiseHand.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { RaiseHand, RaiseHandProps } from ".";
 import faker from "faker";
+import { RaiseHand, RaiseHandProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/RaiseHand",

--- a/packages/flat-components/src/components/ClassroomPage/RaiseHand/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RaiseHand/index.tsx
@@ -1,9 +1,8 @@
-import raiseHandSVG from "./icons/raise-hand.svg";
-import raiseHandActiveSVG from "./icons/raise-hand-active.svg";
-import "./style.less";
-
 import React from "react";
 import { useTranslation } from "react-i18next";
+import raiseHandActiveSVG from "./icons/raise-hand-active.svg";
+import raiseHandSVG from "./icons/raise-hand.svg";
+import "./style.less";
 
 export interface RaiseHandProps {
     isRaiseHand?: boolean;

--- a/packages/flat-components/src/components/ClassroomPage/RecordButton/RecordButton.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RecordButton/RecordButton.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { RecordButton, RecordButtonProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/RecordButton/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RecordButton/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { TopBarRoundBtn } from "../";
 import recordingStartSVG from "./icons/recording-start.svg";
 import recordingStopSVG from "./icons/recording-stop.svg";
-
-import React, { FC, useCallback, useEffect, useRef, useState } from "react";
-import { TopBarRoundBtn } from "../";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface RecordButtonProps {
     isRecording: boolean;

--- a/packages/flat-components/src/components/ClassroomPage/RecordHintTips/RecordHintTips.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RecordHintTips/RecordHintTips.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { RecordHintTips, RecordHintTipsProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/RecordHintTips/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RecordHintTips/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React, { FC } from "react";
 import { CloseOutlined } from "@ant-design/icons";
 import { Button, Tooltip } from "antd";
 import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface RecordHintTipsProps {
     visible: boolean;

--- a/packages/flat-components/src/components/ClassroomPage/RoomInfo/RoomInfo.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RoomInfo/RoomInfo.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { RoomInfo, RoomInfoProps } from ".";
+import { Meta, Story } from "@storybook/react";
 import { RoomStatus } from "../../../types/room";
+import { RoomInfo, RoomInfoProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/RoomInfo",

--- a/packages/flat-components/src/components/ClassroomPage/RoomInfo/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RoomInfo/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
-
-import classNames from "classnames";
 import React, { FC } from "react";
+import classNames from "classnames";
 import { useTranslation } from "react-i18next";
 import { RoomStatus, RoomType } from "../../../types/room";
 import { roomStatusToI18nKey } from "../../../utils/room";
+import "./style.less";
 
 export interface RoomInfoProps {
     roomStatus: RoomStatus;

--- a/packages/flat-components/src/components/ClassroomPage/RoomStoppedModal/RoomStoppedModal.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/RoomStoppedModal/RoomStoppedModal.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { RoomStoppedModal, RoomStoppedModalProps } from ".";
+import { Meta, Story } from "@storybook/react";
 import { RoomStatus } from "../../../types/room";
+import { RoomStoppedModal, RoomStoppedModalProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/RoomStoppedModal",

--- a/packages/flat-components/src/components/ClassroomPage/ScenesController/ScenesController.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/ScenesController/ScenesController.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { ScenesController, ScenesControllerProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/ScenesController/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/ScenesController/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
+import React, { FC, useCallback } from "react";
+import classNames from "classnames";
 import addSceneSVG from "./image/add-scene.svg";
 import nextScenesDisabledSVG from "./image/next-scene-disabled.svg";
 import nextScenesSVG from "./image/next-scene.svg";
 import preScenesDisabledSVG from "./image/previous-scene-disabled.svg";
 import preScenesSVG from "./image/previous-scene.svg";
-
-import React, { FC, useCallback } from "react";
-import classNames from "classnames";
+import "./style.less";
 
 export interface ScenesControllerProps {
     addScene: () => void;

--- a/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/SmallVideoAvatar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/SmallVideoAvatar.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { SmallVideoAvatar, SmallVideoAvatarProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/SmallVideoAvatar/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
 import React from "react";
-import { VideoAvatarProps, VideoAvatar } from "../VideoAvatar";
 import classNames from "classnames";
+import { VideoAvatar, VideoAvatarProps } from "../VideoAvatar";
+import "./style.less";
 
 export type SmallVideoAvatarProps = VideoAvatarProps;
 

--- a/packages/flat-components/src/components/ClassroomPage/Timer/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/Timer/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
-
-import React, { useState, useEffect, useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { useIsUnMounted } from "../../../utils/hooks";
-import { RoomStatus } from "../../../types/room";
+import React, { useEffect, useMemo, useState } from "react";
 import { intervalToDuration } from "date-fns/fp";
+import { useTranslation } from "react-i18next";
+import { RoomStatus } from "../../../types/room";
+import { useIsUnMounted } from "../../../utils/hooks";
+import "./style.less";
 
 export type TimerProps = {
     roomStatus: RoomStatus;

--- a/packages/flat-components/src/components/ClassroomPage/Timer/timer.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/Timer/timer.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { RoomStatus } from "../../../types/room";
 import { Timer, TimerProps } from ".";
 

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBar.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBar.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { TopBar, TopBarProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/TopBarRightBtn.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/TopBarRightBtn.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { TopBarRightBtn, TopBarRightBtnProps } from ".";
-import faker from "faker";
 import { UserAddOutlined } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
+import faker from "faker";
+import { TopBarRightBtn, TopBarRightBtnProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/TopBarRightBtn",

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRightBtn/index.tsx
@@ -1,8 +1,6 @@
-import "./style.less";
-
+import React, { ButtonHTMLAttributes, FC, ReactElement } from "react";
 import classNames from "classnames";
-import React, { ReactElement } from "react";
-import { ButtonHTMLAttributes, FC } from "react";
+import "./style.less";
 
 export interface TopBarRightBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     icon?: ReactElement;

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/TopBarRoundBtn.stories.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/TopBarRoundBtn.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { TopBarRoundBtn, TopBarRoundBtnProps } from ".";
-import faker from "faker";
 import { UserAddOutlined } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
+import faker from "faker";
+import { TopBarRoundBtn, TopBarRoundBtnProps } from ".";
 
 const storyMeta: Meta = {
     title: "ClassroomPage/TopBarRoundBtn",

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/TopBarRoundBtn/index.tsx
@@ -1,7 +1,6 @@
-import "./style.less";
-
 import React, { FC, HTMLAttributes, ReactElement } from "react";
 import classNames from "classnames";
+import "./style.less";
 
 export interface TopBarRoundBtnProps extends HTMLAttributes<HTMLButtonElement> {
     dark?: boolean;

--- a/packages/flat-components/src/components/ClassroomPage/TopBar/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/TopBar/index.tsx
@@ -1,7 +1,6 @@
-import "./style.less";
-
 import React, { FC, ReactNode } from "react";
 import classNames from "classnames";
+import "./style.less";
 
 export * from "./TopBarRightBtn";
 export * from "./TopBarRoundBtn";

--- a/packages/flat-components/src/components/ClassroomPage/VideoAvatar/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/VideoAvatar/index.tsx
@@ -1,15 +1,14 @@
-import "./style.less";
-import cameraSVG from "./icons/camera.svg";
-import cameraDisabledSVG from "./icons/camera-disabled.svg";
-import microphoneSVG from "./icons/microphone.svg";
-import microphoneDisabledSVG from "./icons/microphone-disabled.svg";
-import videoExpandSVG from "./icons/video-expand.svg";
-import placeholderSVG from "./icons/placeholder.svg";
-
 import React, { useState } from "react";
-import { observer } from "mobx-react-lite";
 import classNames from "classnames";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import cameraDisabledSVG from "./icons/camera-disabled.svg";
+import cameraSVG from "./icons/camera.svg";
+import microphoneDisabledSVG from "./icons/microphone-disabled.svg";
+import microphoneSVG from "./icons/microphone.svg";
+import placeholderSVG from "./icons/placeholder.svg";
+import videoExpandSVG from "./icons/video-expand.svg";
+import "./style.less";
 
 export interface AvatarUser {
     name: string;

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/CloudStorageFileList.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/CloudStorageFileList.stories.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo, useState } from "react";
-import { Story, Meta } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-
-import { CloudStorageFileList, CloudStorageFileListProps } from "./index";
 import { CloudStorageFile } from "../types";
+import { CloudStorageFileList, CloudStorageFileListProps } from "./index";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/CloudStorageFileListFileName.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/CloudStorageFileListFileName.tsx
@@ -1,9 +1,8 @@
-import fileMenusSVG from "./icons/file-menus.svg";
-
 import React from "react";
 import { Button, Dropdown, Menu } from "antd";
 import { CloudStorageFileTitle } from "../CloudStorageFileTitle";
 import { CloudStorageFile, CloudStorageFileName } from "../types";
+import fileMenusSVG from "./icons/file-menus.svg";
 
 export interface CloudStorageFileListFileNameProps {
     file: CloudStorageFile;

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileList/index.tsx
@@ -1,18 +1,17 @@
-import "./style.less";
-import emptyFileSVG from "./icons/empty-file.svg";
-
 import React, { useCallback, useMemo, useRef } from "react";
 import { Table } from "antd";
-import prettyBytes from "pretty-bytes";
-import { format } from "date-fns";
 import { ColumnsType } from "antd/lib/table";
-import { CloudStorageFile } from "../types";
+import { format } from "date-fns";
+import prettyBytes from "pretty-bytes";
+import { useTranslation } from "react-i18next";
 import { CloudStorageFileListHeadTip } from "../CloudStorageFileListHeadTip";
+import { CloudStorageFile } from "../types";
 import {
     CloudStorageFileListFileName,
     CloudStorageFileListFileNameProps,
 } from "./CloudStorageFileListFileName";
-import { useTranslation } from "react-i18next";
+import emptyFileSVG from "./icons/empty-file.svg";
+import "./style.less";
 
 export interface CloudStorageFileListProps
     extends Pick<

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileListHeadTip/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileListHeadTip/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React from "react";
 import { QuestionCircleOutlined } from "@ant-design/icons";
-import classNames from "classnames";
 import { Tooltip, TooltipProps } from "antd";
+import classNames from "classnames";
+import "./style.less";
 
 export type CloudStorageFileListHeadTipProps = TooltipProps;
 

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/CloudStorageFileTitle.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/CloudStorageFileTitle.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Story, Meta } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-
 import { CloudStorageFileTitle, CloudStorageFileTitleProps } from "./index";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/CloudStorageFileTitleRename.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/CloudStorageFileTitleRename.tsx
@@ -1,9 +1,8 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Button, Input } from "antd";
+import { CloudStorageFileName } from "../types";
 import checkSVG from "./icons/check.svg";
 import crossSVG from "./icons/cross.svg";
-
-import { Button, Input } from "antd";
-import React, { useEffect, useRef, useState } from "react";
-import { CloudStorageFileName } from "../types";
 
 export interface CloudStorageFileTitleRenameProps {
     fileUUID: string;

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageFileTitle/index.tsx
@@ -1,21 +1,20 @@
-import "./style.less";
-import defaultSVG from "./icons/default.svg";
+import React, { useMemo } from "react";
+import classNames from "classnames";
+import { useTranslation } from "react-i18next";
+import { CloudStorageConvertStatusType, CloudStorageFileName } from "../types";
+import { CloudStorageFileTitleRename } from "./CloudStorageFileTitleRename";
 import audioSVG from "./icons/audio.svg";
+import convertErrorSVG from "./icons/convert-error.svg";
+import convertingSVG from "./icons/converting.svg";
+import defaultSVG from "./icons/default.svg";
+import iceSVG from "./icons/ice.svg";
 import imgSVG from "./icons/img.svg";
 import pdfSVG from "./icons/pdf.svg";
 import pptSVG from "./icons/ppt.svg";
+import vfSVG from "./icons/vf.svg";
 import videoSVG from "./icons/video.svg";
 import wordSVG from "./icons/word.svg";
-import convertingSVG from "./icons/converting.svg";
-import convertErrorSVG from "./icons/convert-error.svg";
-import vfSVG from "./icons/vf.svg";
-import iceSVG from "./icons/ice.svg";
-
-import React, { useMemo } from "react";
-import classNames from "classnames";
-import { CloudStorageConvertStatusType, CloudStorageFileName } from "../types";
-import { CloudStorageFileTitleRename } from "./CloudStorageFileTitleRename";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface CloudStorageFileTitleProps
     extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> {

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageSkeletons/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageSkeletons/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
 import React from "react";
 import { Skeleton } from "antd";
 import classNames from "classnames";
+import "./style.less";
 
 export interface CloudStorageSkeletonsProps {
     isCompactMode: boolean;

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadItem/CloudStorageUploadItem.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadItem/CloudStorageUploadItem.stories.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { Story, Meta } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-
-import { CloudStorageUploadItem, CloudStorageUploadItemProps } from "./index";
 import { CloudStorageUploadStatusType } from "../types";
+import { CloudStorageUploadItem, CloudStorageUploadItemProps } from "./index";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadItem/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadItem/index.tsx
@@ -1,14 +1,13 @@
-import "./style.less";
-import checkSVG from "./icons/check.svg";
-import trashBinSVG from "./icons/trash-bin.svg";
-import retrySVG from "./icons/retry.svg";
-
 import React from "react";
 import { Button } from "antd";
 import classNames from "classnames";
+import { useTranslation } from "react-i18next";
 import { CloudStorageFileTitle } from "../CloudStorageFileTitle";
 import { CloudStorageUploadTask } from "../types";
-import { useTranslation } from "react-i18next";
+import checkSVG from "./icons/check.svg";
+import retrySVG from "./icons/retry.svg";
+import trashBinSVG from "./icons/trash-bin.svg";
+import "./style.less";
 
 export interface CloudStorageUploadItemProps
     extends Pick<CloudStorageUploadTask, "uploadID" | "fileName" | "percent" | "status"> {

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadPanel/CloudStorageUploadPanel.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadPanel/CloudStorageUploadPanel.stories.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Story, Meta } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
 import Chance from "chance";
 import faker from "faker";
-
-import { CloudStorageUploadPanel, CloudStorageUploadPanelProps } from "./index";
-import { CloudStorageUploadTask } from "../types";
 import CloudStorageUploadItem from "../CloudStorageUploadItem";
+import { CloudStorageUploadTask } from "../types";
+import { CloudStorageUploadPanel, CloudStorageUploadPanelProps } from "./index";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadPanel/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadPanel/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
-import arrowSVG from "./icons/panel-arrow.svg";
-import closeSVG from "./icons/panel-close.svg";
-
 import React, { FC } from "react";
 import { Button } from "antd";
 import classNames from "classnames";
 import { useResizeDetector } from "react-resize-detector";
 import { CloudStorageUploadTitle } from "../CloudStorageUploadTitle";
+import arrowSVG from "./icons/panel-arrow.svg";
+import closeSVG from "./icons/panel-close.svg";
+import "./style.less";
 
 export interface CloudStorageUploadPanelProps
     extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/CloudStorageUploadTitle.stories.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/CloudStorageUploadTitle.stories.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { Story, Meta } from "@storybook/react";
-import faker from "faker";
-
-import { CloudStorageUploadTitle, CloudStorageUploadTitleProps } from "./index";
+import { Meta, Story } from "@storybook/react";
 import { Chance } from "chance";
+import faker from "faker";
+import { CloudStorageUploadTitle, CloudStorageUploadTitleProps } from "./index";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/index.tsx
+++ b/packages/flat-components/src/components/CloudStorage/CloudStorageUploadTitle/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
+import React from "react";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { Progress } from "antd";
-import React from "react";
 import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface CloudStorageUploadTitleProps {
     finishWithError?: boolean;

--- a/packages/flat-components/src/components/DeviceTestPage/CameraTest/index.tsx
+++ b/packages/flat-components/src/components/DeviceTestPage/CameraTest/index.tsx
@@ -1,11 +1,10 @@
-import "./style.less";
-import cameraDisabledSVG from "../icons/camera-disabled.svg";
-
 import React from "react";
 import classNames from "classnames";
+import { useTranslation } from "react-i18next";
 import { Device } from "../constants";
 import { DeviceTestSelect } from "../DeviceTestSelect";
-import { useTranslation } from "react-i18next";
+import cameraDisabledSVG from "../icons/camera-disabled.svg";
+import "./style.less";
 
 export interface CameraTestProps {
     cameraDevices?: Device[];

--- a/packages/flat-components/src/components/DeviceTestPage/DeviceTestSelect/index.tsx
+++ b/packages/flat-components/src/components/DeviceTestPage/DeviceTestSelect/index.tsx
@@ -1,10 +1,9 @@
-import disabledSVG from "../icons/disabled.svg";
-import "./style.less";
-
 import React from "react";
 import { Button, Select } from "antd";
-import { Device } from "../constants";
 import { useTranslation } from "react-i18next";
+import { Device } from "../constants";
+import disabledSVG from "../icons/disabled.svg";
+import "./style.less";
 
 export interface DeviceTestSelectProps {
     devices?: Device[];

--- a/packages/flat-components/src/components/DeviceTestPage/MicrophoneTest/index.tsx
+++ b/packages/flat-components/src/components/DeviceTestPage/MicrophoneTest/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Device } from "../constants";
 import { DeviceTestSelect } from "../DeviceTestSelect";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface MicrophoneTestProps {
     microphoneDevices?: Device[];

--- a/packages/flat-components/src/components/DeviceTestPage/SpeakerTest/index.tsx
+++ b/packages/flat-components/src/components/DeviceTestPage/SpeakerTest/index.tsx
@@ -1,13 +1,12 @@
-import playSVG from "../icons/play.svg";
-import stopSVG from "../icons/stop.svg";
-import "./style.less";
-
-import { Button } from "antd";
 import React, { useRef, useState } from "react";
+import { Button } from "antd";
+import { useTranslation } from "react-i18next";
 import { Device } from "../constants";
 import { DeviceTestSelect } from "../DeviceTestSelect";
-import { useTranslation } from "react-i18next";
+import playSVG from "../icons/play.svg";
+import stopSVG from "../icons/stop.svg";
 import audioLocalResourceMP3 from "./assets/media/Goldberg Variations, BWV 988 - 05 - Variatio 4 a 1 Clav.mp3";
+import "./style.less";
 
 export interface SpeakerTestProps {
     speakerDevices?: Device[];

--- a/packages/flat-components/src/components/DeviceTestPage/index.tsx
+++ b/packages/flat-components/src/components/DeviceTestPage/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
-
-import { Button, Checkbox } from "antd";
 import React from "react";
+import { Button, Checkbox } from "antd";
+import { useTranslation } from "react-i18next";
 import { CameraTest } from "./CameraTest";
 import { Device } from "./constants";
 import { MicrophoneTest } from "./MicrophoneTest";
 import { SpeakerTest } from "./SpeakerTest";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export type { Device };
 

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/EditRoomBody.stories.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/EditRoomBody.stories.tsx
@@ -1,8 +1,8 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
-import { EditRoomBody, EditRoomBodyProps, Region } from ".";
 import { RoomType } from "../../../types/room";
+import { EditRoomBody, EditRoomBodyProps, Region } from ".";
 
 const storyMeta: Meta = {
     title: "EditRoomPage/EditRoomBody",

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
@@ -1,21 +1,20 @@
-import "./style.less";
-import cnSVG from "./icons/cn.svg";
-import inSVG from "./icons/in.svg";
-import gbSVG from "./icons/gb.svg";
-import usSVG from "./icons/us.svg";
-import sgSVG from "./icons/sg.svg";
-
+import React, { useMemo, useRef, useState } from "react";
 import { Button, Checkbox, Dropdown, Form, Input, Menu, Modal } from "antd";
 import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { addWeeks, endOfDay, getDay } from "date-fns";
-import React, { useMemo, useRef, useState } from "react";
-import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import { PeriodicEndType, RoomType, Week } from "../../../types/room";
+import { ClassPicker } from "../../HomePage/ClassPicker";
+import cnSVG from "./icons/cn.svg";
+import gbSVG from "./icons/gb.svg";
+import inSVG from "./icons/in.svg";
+import sgSVG from "./icons/sg.svg";
+import usSVG from "./icons/us.svg";
 import { renderBeginTimePicker } from "./renderBeginTimePicker";
 import { renderEndTimePicker } from "./renderEndTimePicker";
 import { renderPeriodicForm } from "./renderPeriodicForm";
-import { ClassPicker } from "../../HomePage/ClassPicker";
+import "./style.less";
 
 export enum Region {
     CN_HZ = "cn-hz",

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderBeginTimePicker.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderBeginTimePicker.tsx
@@ -1,9 +1,8 @@
+import React from "react";
 import { Form } from "antd";
 import { FormInstance, RuleObject } from "antd/lib/form";
 import { addMinutes, isAfter, isBefore, setHours, startOfDay } from "date-fns";
-import React from "react";
 import { TFunction } from "react-i18next";
-import { EditRoomFormValues } from ".";
 import {
     compareDay,
     compareHour,
@@ -14,6 +13,7 @@ import {
 } from "../../../utils/room";
 import { FullTimePicker } from "../FullTimePicker";
 import { MIN_CLASS_DURATION } from "./constants";
+import { EditRoomFormValues } from ".";
 
 export function renderBeginTimePicker(
     t: TFunction<string>,

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderEndTimePicker.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderEndTimePicker.tsx
@@ -1,12 +1,12 @@
+import React from "react";
 import { Form } from "antd";
 import { FormInstance, RuleObject } from "antd/lib/form";
 import { addMinutes, isAfter, isBefore, setHours } from "date-fns";
-import React from "react";
 import { TFunction } from "react-i18next";
-import type { EditRoomFormValues } from ".";
 import { compareDay, compareHour, excludeRange } from "../../../utils/room";
 import { FullTimePicker } from "../FullTimePicker";
 import { MIN_CLASS_DURATION } from "./constants";
+import { EditRoomFormValues } from ".";
 
 export function renderEndTimePicker(
     t: TFunction<string>,

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderPeriodicForm.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/renderPeriodicForm.tsx
@@ -1,14 +1,14 @@
+import React from "react";
 import { Col, Form, InputNumber, Row } from "antd";
 import { FormInstance, RuleObject } from "antd/lib/form";
 import { endOfDay, getDay, isBefore, startOfDay } from "date-fns";
-import React from "react";
 import { TFunction } from "react-i18next";
-import { EditRoomFormValues } from ".";
 import { Week } from "../../../types/room";
 import { formatISODayWeekiii, getWeekNames, syncPeriodicEndAmount } from "../../../utils/room";
 import { DatePicker } from "../FullTimePicker";
 import { PeriodicEndTypeSelector } from "../PeriodicEndTypeSelector";
 import { WeekRateSelector } from "../WeekRateSelector";
+import { EditRoomFormValues } from ".";
 
 export const renderPeriodicForm = (t: TFunction<string>, lang: string) =>
     function renderPeriodicForm(form: FormInstance<EditRoomFormValues>) {

--- a/packages/flat-components/src/components/EditRoomPage/FullTimePicker/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/FullTimePicker/index.tsx
@@ -1,12 +1,10 @@
 // https://ant.design/docs/react/replace-moment
-
-import "./style.less";
-
 import React, { FC, useContext } from "react";
 import { Col, Row } from "antd";
-import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
-import generatePicker, { PickerTimeProps, PickerProps } from "antd/es/date-picker/generatePicker";
+import generatePicker, { PickerProps, PickerTimeProps } from "antd/es/date-picker/generatePicker";
 import { ConfigContext } from "antd/lib/config-provider";
+import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
+import "./style.less";
 
 export type DatePickerProps = PickerProps<Date>;
 

--- a/packages/flat-components/src/components/EditRoomPage/PeriodicEndTypeSelector/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/PeriodicEndTypeSelector/index.tsx
@@ -1,6 +1,6 @@
+import React, { FC } from "react";
 import { Select } from "antd";
 import { SelectProps } from "antd/lib/select";
-import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { PeriodicEndType } from "../../../types/room";
 

--- a/packages/flat-components/src/components/EditRoomPage/WeekRateSelector/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/WeekRateSelector/index.tsx
@@ -1,5 +1,5 @@
-import { Select } from "antd";
 import React, { FC } from "react";
+import { Select } from "antd";
 import { SelectProps } from "antd/lib/select";
 import { Week } from "../../../types/room";
 import { getWeekName } from "../../../utils/room";

--- a/packages/flat-components/src/components/ErrorPage/ErrorPage.stories.tsx
+++ b/packages/flat-components/src/components/ErrorPage/ErrorPage.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { ErrorPage, ErrorPageProps } from ".";
 

--- a/packages/flat-components/src/components/ErrorPage/index.tsx
+++ b/packages/flat-components/src/components/ErrorPage/index.tsx
@@ -1,10 +1,9 @@
-import errorSVG from "./icons/error.svg";
-import "./style.less";
-
 import React, { useEffect, useState } from "react";
 import { Button } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
+import errorSVG from "./icons/error.svg";
+import "./style.less";
 
 export type ErrorPageProps = {};
 

--- a/packages/flat-components/src/components/FlatThemeProvider/index.tsx
+++ b/packages/flat-components/src/components/FlatThemeProvider/index.tsx
@@ -1,8 +1,8 @@
-import "../../theme/index.less";
 import React, { FC } from "react";
 import classNames from "classnames";
-import { useDarkMode, FlatPrefersColorScheme } from "./useDarkMode";
 import { useIsomorphicLayoutEffect } from "react-use";
+import { FlatPrefersColorScheme, useDarkMode } from "./useDarkMode";
+import "../../theme/index.less";
 
 export * from "./useDarkMode";
 

--- a/packages/flat-components/src/components/HomePage/ClassPicker/ClassPicker.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/ClassPicker/ClassPicker.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
+import { Meta, Story } from "@storybook/react";
 import { ClassPicker, ClassPickerItemType, ClassPickerProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/HomePage/ClassPicker/ClassPickerItem.tsx
+++ b/packages/flat-components/src/components/HomePage/ClassPicker/ClassPickerItem.tsx
@@ -1,10 +1,9 @@
-import bigClassSVG from "./icons/big-class.svg";
-import oneToOneSVG from "./icons/one-to-one.svg";
-import smallClassSVG from "./icons/small-class.svg";
-
 import React from "react";
 import { Radio } from "antd";
 import { useTranslation } from "react-i18next";
+import bigClassSVG from "./icons/big-class.svg";
+import oneToOneSVG from "./icons/one-to-one.svg";
+import smallClassSVG from "./icons/small-class.svg";
 
 export type ClassPickerItemType = "OneToOne" | "BigClass" | "SmallClass";
 

--- a/packages/flat-components/src/components/HomePage/ClassPicker/index.tsx
+++ b/packages/flat-components/src/components/HomePage/ClassPicker/index.tsx
@@ -1,9 +1,8 @@
-import "./index.less";
-
 import React from "react";
 import { Radio } from "antd";
 import classNames from "classnames";
 import { ClassPickerItem, ClassPickerItemType } from "./ClassPickerItem";
+import "./index.less";
 
 export type { ClassPickerItemType } from "./ClassPickerItem";
 

--- a/packages/flat-components/src/components/HomePage/HomePageHeroButton/HomePageHeroButton.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/HomePageHeroButton/HomePageHeroButton.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { HomePageHeroButtons, HomePageHeroButtonsProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/HomePage/HomePageHeroButton/index.tsx
+++ b/packages/flat-components/src/components/HomePage/HomePageHeroButton/index.tsx
@@ -1,10 +1,10 @@
-import "./style.less";
-import joinSVG from "./icons/join.svg";
-import createSVG from "./icons/create.svg";
-import scheduleSVG from "./icons/schedule.svg";
 import React from "react";
 import { Button } from "antd";
 import { useTranslation } from "react-i18next";
+import createSVG from "./icons/create.svg";
+import joinSVG from "./icons/join.svg";
+import scheduleSVG from "./icons/schedule.svg";
+import "./style.less";
 
 type HomePageHeroButtonType = "join" | "create" | "schedule";
 

--- a/packages/flat-components/src/components/HomePage/RoomList/RoomList.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomList.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, Story } from "@storybook/react";
-import faker from "faker";
-import { Chance } from "chance";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
+import { Chance } from "chance";
+import faker from "faker";
 import { RoomList, RoomListDate, RoomListItem, RoomListProps } from ".";
 
 const chance = new Chance();

--- a/packages/flat-components/src/components/HomePage/RoomList/RoomListDate.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomListDate.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { RoomListDate, RoomListDateProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/HomePage/RoomList/RoomListItem.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomListItem.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { RoomListItem, RoomListItemProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/HomePage/RoomList/RoomListSkeletons.stories.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomListSkeletons.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { RoomListSkeletons } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/HomePage/RoomList/index.tsx
+++ b/packages/flat-components/src/components/HomePage/RoomList/index.tsx
@@ -1,14 +1,13 @@
-import "./style.less";
+import React, { PropsWithChildren, ReactElement } from "react";
+import { Button, Dropdown, Menu, Skeleton } from "antd";
+import classNames from "classnames";
+import { format, isToday, isTomorrow } from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+import { useTranslation } from "react-i18next";
 import calendarSVG from "./icons/calendar.svg";
 import emptyHistorySVG from "./icons/empty-history.svg";
 import emptyRoomSVG from "./icons/empty-room.svg";
-
-import React, { PropsWithChildren, ReactElement } from "react";
-import { format, isToday, isTomorrow } from "date-fns";
-import { zhCN, enUS } from "date-fns/locale";
-import classNames from "classnames";
-import { Button, Dropdown, Menu, Skeleton } from "antd";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface RoomListDateProps {
     date: Date;

--- a/packages/flat-components/src/components/InviteModal/InviteModal.stories.tsx
+++ b/packages/flat-components/src/components/InviteModal/InviteModal.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { InviteModal, InviteModalProps } from ".";
-import { RoomStatus, RoomType } from "../../types/room";
 import { message } from "antd";
+import { RoomStatus, RoomType } from "../../types/room";
+import { InviteModal, InviteModalProps } from ".";
 
 const storyMeta: Meta = {
     title: "Components/InviteModal",

--- a/packages/flat-components/src/components/InviteModal/index.tsx
+++ b/packages/flat-components/src/components/InviteModal/index.tsx
@@ -1,11 +1,10 @@
-import "./index.less";
-
 import React, { useMemo } from "react";
 import { Modal } from "antd";
 import { differenceInCalendarDays, format } from "date-fns/fp";
+import { useTranslation } from "react-i18next";
 import { RoomInfo, Week } from "../../types/room";
 import { formatInviteCode, getWeekNames } from "../../utils/room";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 const completeTimeFormat = format("yyyy-MM-dd HH:mm");
 const onlySuffixTimeFormat = format("HH:mm");

--- a/packages/flat-components/src/components/LoadingPage/LoadingPage.stories.tsx
+++ b/packages/flat-components/src/components/LoadingPage/LoadingPage.stories.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import faker from "faker";
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { LoadingPage, LoadingPageProps } from ".";
 

--- a/packages/flat-components/src/components/LoadingPage/index.tsx
+++ b/packages/flat-components/src/components/LoadingPage/index.tsx
@@ -1,10 +1,9 @@
-import "./style.less";
-import loadingGIF from "./icons/loading.gif";
-
 import React, { FC, useCallback, useEffect, useState } from "react";
-import classNames from "classnames";
 import { Button } from "antd";
+import classNames from "classnames";
 import { useTranslation } from "react-i18next";
+import loadingGIF from "./icons/loading.gif";
+import "./style.less";
 
 export interface LoadingPageProps {
     text?: string;

--- a/packages/flat-components/src/components/LoginPage/LoginChannel/LoginChannel.stories.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginChannel/LoginChannel.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { LoginChannel, LoginChannelProps } from "../LoginChannel";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/LoginPage/LoginChannel/index.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginChannel/index.tsx
@@ -1,10 +1,9 @@
-import wechatSVG from "./icons/wechat.svg";
-import githubSVG from "./icons/github.svg";
-import "./index.less";
-
 import React from "react";
 import { Button } from "antd";
 import { useTranslation } from "react-i18next";
+import githubSVG from "./icons/github.svg";
+import wechatSVG from "./icons/wechat.svg";
+import "./index.less";
 
 export type LoginChannelType = "wechat" | "github";
 

--- a/packages/flat-components/src/components/LoginPage/LoginContent/LoginContent.stories.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginContent/LoginContent.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { Meta, Story } from "@storybook/react";
 import { LoginContent, LoginContentProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/LoginPage/LoginContent/index.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginContent/index.tsx
@@ -1,12 +1,11 @@
 /* eslint react/jsx-no-target-blank: off */
+import React, { useState } from "react";
+import { Checkbox, message } from "antd";
+import { useTranslation } from "react-i18next";
+import { CSSTransition, SwitchTransition } from "react-transition-group";
+import { LoginChannel, LoginChannelType } from "../LoginChannel";
 import logoSVG from "./icons/logo.svg";
 import "./index.less";
-
-import React, { useState } from "react";
-import { LoginChannel, LoginChannelType } from "../LoginChannel";
-import { CSSTransition, SwitchTransition } from "react-transition-group";
-import { message, Checkbox } from "antd";
-import { useTranslation } from "react-i18next";
 
 export interface LoginContentProps {
     onLogin: (loginChannel: LoginChannelType) => React.ReactElement | undefined;

--- a/packages/flat-components/src/components/LoginPage/LoginPanel.stories.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginPanel.stories.tsx
@@ -1,8 +1,7 @@
-import QRCodeSVG from "./icons/qr-code.svg";
-
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { Modal } from "antd";
-import React from "react";
+import QRCodeSVG from "./icons/qr-code.svg";
 import { LoginChannelType, LoginPanel, LoginPanelProps } from ".";
 
 const storyMeta: Meta = {

--- a/packages/flat-components/src/components/LoginPage/index.tsx
+++ b/packages/flat-components/src/components/LoginPage/index.tsx
@@ -1,11 +1,10 @@
-import coverSVG from "./icons/cover.svg";
-import bgTopLeftSVG from "./icons/bg-top-left.svg";
-import bgBottomRightSVG from "./icons/bg-bottom-right.svg";
-import bgBottomLeftSVG from "./icons/bg-bottom-left.svg";
-import "./index.less";
-
 import React from "react";
+import bgBottomLeftSVG from "./icons/bg-bottom-left.svg";
+import bgBottomRightSVG from "./icons/bg-bottom-right.svg";
+import bgTopLeftSVG from "./icons/bg-top-left.svg";
+import coverSVG from "./icons/cover.svg";
 import { LoginContent, LoginContentProps } from "./LoginContent";
+import "./index.less";
 
 export type { LoginChannelType } from "./LoginChannel";
 

--- a/packages/flat-components/src/components/MainPageLayout/MainPageHeader/MainPageHeader.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageHeader/MainPageHeader.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { MainPageHeader, MainPageHeaderProps } from ".";
 import { BrowserRouter as Router } from "react-router-dom";
+import { MainPageHeader, MainPageHeaderProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageHeader",

--- a/packages/flat-components/src/components/MainPageLayout/MainPageHeader/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageHeader/index.tsx
@@ -1,9 +1,8 @@
-import backSVG from "./icons/back.svg";
-import "./index.less";
-
 import React from "react";
 import { Divider } from "antd";
 import { useTranslation } from "react-i18next";
+import backSVG from "./icons/back.svg";
+import "./index.less";
 
 export interface MainPageHeaderProps {
     onBackPreviousPage?: () => void;

--- a/packages/flat-components/src/components/MainPageLayout/MainPageLayout.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageLayout.stories.tsx
@@ -1,7 +1,5 @@
 /* eslint react/display-name: off */
-import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
-import { MainPageLayout, MainPageLayoutProps } from ".";
 import {
     CloudFilled,
     CloudOutlined,
@@ -10,7 +8,9 @@ import {
     ToolFilled,
     ToolOutlined,
 } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
 import faker from "faker";
+import { MainPageLayout, MainPageLayoutProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageLayout",

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNav/MainPageNav.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNav/MainPageNav.stories.tsx
@@ -1,7 +1,5 @@
 /* eslint react/display-name: off */
-import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
-import { MainPageNav, MainPageNavProps } from ".";
 import {
     CloudFilled,
     CloudOutlined,
@@ -10,6 +8,8 @@ import {
     ToolFilled,
     ToolOutlined,
 } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
+import { MainPageNav, MainPageNavProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageNav",

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNav/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNav/index.tsx
@@ -1,8 +1,8 @@
-import "./style.less";
 import React from "react";
 import classNames from "classnames";
-import { MainPageLayoutItem } from "../types";
 import { MainPageNavAvatar, MainPageNavAvatarProps } from "../MainPageNavAvatar";
+import { MainPageLayoutItem } from "../types";
+import "./style.less";
 
 export interface MainPageNavProps extends MainPageNavAvatarProps {
     /** when an item is clicked */
@@ -16,11 +16,11 @@ export interface MainPageNavProps extends MainPageNavAvatarProps {
     /** function to generate placeholder avatar */
     generateAvatar: (uid: string) => string;
 }
-
 export const MainPageNav: React.FC<MainPageNavProps> = ({
     avatarSrc,
     userName,
     onClick,
+
     activeKeys,
     sideMenu,
     sideMenuFooter,

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/MainPageNavAvatar.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/MainPageNavAvatar.stories.tsx
@@ -1,8 +1,8 @@
 /* eslint react/display-name: off */
-import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
-import { MainPageNavAvatar, MainPageNavAvatarProps } from ".";
 import { CloudOutlined } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
+import { MainPageNavAvatar, MainPageNavAvatarProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageNavAvatar",

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
-import { Avatar, Divider, Popover } from "antd";
 import React, { useState } from "react";
+import { Avatar, Divider, Popover } from "antd";
 import { MainPageLayoutItem } from "../types";
+import "./style.less";
 
 export interface MainPageNavAvatarProps {
     /** user avatar src*/

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/MainPageNavHorizontal.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/MainPageNavHorizontal.stories.tsx
@@ -1,15 +1,15 @@
 /* eslint react/display-name: off */
-import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
-import { MainPageNavHorizontal, MainPageNavHorizontalProps } from ".";
 import {
     CloudFilled,
     CloudOutlined,
+    DownloadOutlined,
     HomeFilled,
     HomeOutlined,
-    DownloadOutlined,
     SettingOutlined,
 } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
+import { MainPageNavHorizontal, MainPageNavHorizontalProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageNavHorizontal",

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavHorizontal/index.tsx
@@ -1,10 +1,10 @@
-import "./style.less";
 import React from "react";
-import classNames from "classnames";
-import { MainPageLayoutItem } from "../types";
-import { MainPageNavAvatar, MainPageNavAvatarProps } from "../MainPageNavAvatar";
 import { Tabs } from "antd";
+import classNames from "classnames";
 import { MainPageHeader, MainPageHeaderProps } from "../MainPageHeader";
+import { MainPageNavAvatar, MainPageNavAvatarProps } from "../MainPageNavAvatar";
+import { MainPageLayoutItem } from "../types";
+import "./style.less";
 
 export interface MainPageNavHorizontalProps extends MainPageNavAvatarProps, MainPageHeaderProps {
     /** when an item is clicked */

--- a/packages/flat-components/src/components/MainPageLayout/MainPageSubMenu/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageSubMenu/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
 import React from "react";
 import classNames from "classnames";
 import { MainPageLayoutItem } from "../types";
+import "./style.less";
 
 export interface MainPageSubMenuProps {
     /** when an item is clicked */

--- a/packages/flat-components/src/components/MainPageLayout/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/index.tsx
@@ -1,8 +1,8 @@
-import "./style.less";
 import React from "react";
-import { MainPageLayoutItem } from "./types";
 import { MainPageNav, MainPageNavProps } from "./MainPageNav";
 import { MainPageSubMenu, MainPageSubMenuProps } from "./MainPageSubMenu";
+import { MainPageLayoutItem } from "./types";
+import "./style.less";
 
 export * from "./MainPageHeader";
 export type { MainPageLayoutItem } from "./types";

--- a/packages/flat-components/src/components/MainPageLayoutHorizontal/MainPageLayoutHorizontal.stories.tsx
+++ b/packages/flat-components/src/components/MainPageLayoutHorizontal/MainPageLayoutHorizontal.stories.tsx
@@ -1,7 +1,5 @@
 /* eslint react/display-name: off */
-import { Meta, Story } from "@storybook/react";
 import React, { PropsWithChildren } from "react";
-import { MainPageLayoutHorizontal, MainPageLayoutHorizontalProps } from ".";
 import {
     CloudFilled,
     CloudOutlined,
@@ -9,7 +7,9 @@ import {
     HomeOutlined,
     ToolOutlined,
 } from "@ant-design/icons";
+import { Meta, Story } from "@storybook/react";
 import faker from "faker";
+import { MainPageLayoutHorizontal, MainPageLayoutHorizontalProps } from ".";
 
 const storyMeta: Meta = {
     title: "MainPageLayout/MainPageLayoutHorizontal",

--- a/packages/flat-components/src/components/MainPageLayoutHorizontal/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayoutHorizontal/index.tsx
@@ -1,11 +1,11 @@
-import "./style.less";
 import React from "react";
-import { MainPageLayoutItem } from "../MainPageLayout/types";
 import {
     MainPageNavHorizontal,
     MainPageNavHorizontalProps,
 } from "../MainPageLayout/MainPageNavHorizontal";
 import { MainPageSubMenu, MainPageSubMenuProps } from "../MainPageLayout/MainPageSubMenu";
+import { MainPageLayoutItem } from "../MainPageLayout/types";
+import "./style.less";
 
 export interface MainPageLayoutHorizontalProps
     extends MainPageNavHorizontalProps,

--- a/packages/flat-components/src/components/PeriodicRoomPage/MoreMenu.tsx
+++ b/packages/flat-components/src/components/PeriodicRoomPage/MoreMenu.tsx
@@ -1,11 +1,10 @@
-import moreMenuSVG from "./icons/more-menu.svg";
-
 import React, { useState } from "react";
 import { Dropdown, Menu, message } from "antd";
+import { useTranslation } from "react-i18next";
 import { RoomInfo } from "../../types/room";
 import { InviteModal } from "../InviteModal";
 import { CancelSubPeriodicRoomModal } from "./CancelSubPeriodicRoomModal";
-import { useTranslation } from "react-i18next";
+import moreMenuSVG from "./icons/more-menu.svg";
 
 export interface MoreMenuProps {
     room: RoomInfo;

--- a/packages/flat-components/src/components/PeriodicRoomPage/PeriodicRoomPanel.stories.tsx
+++ b/packages/flat-components/src/components/PeriodicRoomPage/PeriodicRoomPanel.stories.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { PeriodicRoomPanel, PeriodicRoomPanelProps } from ".";
-import { RoomStatus, RoomType, Week } from "../../types/room";
-import faker from "faker";
 import Chance from "chance";
+import faker from "faker";
+import { RoomStatus, RoomType, Week } from "../../types/room";
+import { PeriodicRoomPanel, PeriodicRoomPanelProps } from ".";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/components/PeriodicRoomPage/index.tsx
+++ b/packages/flat-components/src/components/PeriodicRoomPage/index.tsx
@@ -1,16 +1,15 @@
-import "./index.less";
-
 import React, { useState } from "react";
 import { Button, Table } from "antd";
 import { getDay } from "date-fns";
 import { format, formatWithOptions } from "date-fns/fp";
-import { zhCN, enUS } from "date-fns/locale";
+import { enUS, zhCN } from "date-fns/locale";
+import { useTranslation } from "react-i18next";
 import { RoomInfo, RoomStatus, RoomType, Week } from "../../types/room";
 import { getWeekName, getWeekNames } from "../../utils/room";
 import { RoomStatusElement } from "../RoomStatusElement";
-import { MoreMenu } from "./MoreMenu";
 import { CancelPeriodicRoomModal } from "./CancelPeriodicRoomModal";
-import { useTranslation } from "react-i18next";
+import { MoreMenu } from "./MoreMenu";
+import "./index.less";
 
 export interface PeriodicRoomPanelProps {
     rooms: Array<RoomInfo | undefined>;

--- a/packages/flat-components/src/components/RemoveHistoryRoomModal/index.tsx
+++ b/packages/flat-components/src/components/RemoveHistoryRoomModal/index.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal } from "antd";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface RemoveHistoryRoomModalProps {
     visible: boolean;

--- a/packages/flat-components/src/components/RemoveRoomModal/index.tsx
+++ b/packages/flat-components/src/components/RemoveRoomModal/index.tsx
@@ -1,8 +1,7 @@
-import "./style.less";
-
-import { Button, Checkbox, Modal } from "antd";
 import React, { useState } from "react";
+import { Button, Checkbox, Modal } from "antd";
 import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface RemoveRoomModalProps {
     cancelModalVisible: boolean;

--- a/packages/flat-components/src/components/RoomDetailPage/RoomDetailBody/RoomDetailBody.stories.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/RoomDetailBody/RoomDetailBody.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { RoomDetailBody, RoomDetailBodyProps } from ".";
 import { RoomStatus, RoomType } from "../../../types/room";
+import { RoomDetailBody, RoomDetailBodyProps } from ".";
 
 const storyMeta: Meta = {
     title: "RoomDetailPage/RoomDetailBody",

--- a/packages/flat-components/src/components/RoomDetailPage/RoomDetailBody/index.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/RoomDetailBody/index.tsx
@@ -1,15 +1,14 @@
+import React, { useMemo } from "react";
+import { formatDistanceStrict } from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { RoomInfo, RoomType } from "../../../types/room";
+import { formatInviteCode, formatTime } from "../../../utils/room";
+import { RoomStatusElement } from "../../RoomStatusElement";
 import homeIconGraySVG from "./icons/home-icon-gray.svg";
 import roomTypeSVG from "./icons/room-type.svg";
 import "./index.less";
-
-import React, { useMemo } from "react";
-import { formatInviteCode, formatTime } from "../../../utils/room";
-import { formatDistanceStrict } from "date-fns";
-import { zhCN, enUS } from "date-fns/locale";
-import { RoomInfo, RoomType } from "../../../types/room";
-import { RoomStatusElement } from "../../RoomStatusElement";
-import { useTranslation } from "react-i18next";
-import { observer } from "mobx-react-lite";
 
 export interface RoomDetailBodyProps {
     roomInfo: RoomInfo;

--- a/packages/flat-components/src/components/RoomDetailPage/RoomDetailFooter/RoomDetailFooter.stories.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/RoomDetailFooter/RoomDetailFooter.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { RoomDetailFooter, RoomDetailFooterProps } from ".";
-import { RoomStatus, RoomType, Week } from "../../../types/room";
 import { BrowserRouter as Router } from "react-router-dom";
+import { RoomStatus, RoomType, Week } from "../../../types/room";
+import { RoomDetailFooter, RoomDetailFooterProps } from ".";
 
 const storyMeta: Meta = {
     title: "RoomDetailPage/RoomDetailFooter",

--- a/packages/flat-components/src/components/RoomDetailPage/RoomDetailFooter/index.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/RoomDetailFooter/index.tsx
@@ -1,12 +1,11 @@
-import "./index.less";
-
 import React, { useState } from "react";
 import { Button, message } from "antd";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { RoomInfo, RoomStatus, Week } from "../../../types/room";
 import { InviteModal } from "../../InviteModal";
 import { RemoveRoomModal } from "../../RemoveRoomModal";
-import { useTranslation } from "react-i18next";
+import "./index.less";
 
 export interface RoomDetailFooterProps {
     room: RoomInfo;

--- a/packages/flat-components/src/components/RoomDetailPage/RoomDetailPanel.stories.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/RoomDetailPanel.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { RoomDetailPanel, RoomDetailPanelProps } from ".";
-import { RoomInfo, RoomStatus, RoomType, Week } from "../../types/room";
 import { BrowserRouter as Router } from "react-router-dom";
+import { RoomInfo, RoomStatus, RoomType, Week } from "../../types/room";
+import { RoomDetailPanel, RoomDetailPanelProps } from ".";
 
 const storyMeta: Meta = {
     title: "RoomDetailPage/RoomDetailPagePanel",

--- a/packages/flat-components/src/components/RoomDetailPage/index.tsx
+++ b/packages/flat-components/src/components/RoomDetailPage/index.tsx
@@ -1,8 +1,7 @@
-import "./index.less";
-
 import React from "react";
 import { RoomDetailBody, RoomDetailBodyProps } from "./RoomDetailBody";
 import { RoomDetailFooter, RoomDetailFooterProps } from "./RoomDetailFooter";
+import "./index.less";
 
 export type RoomDetailPanelProps = RoomDetailBodyProps & RoomDetailFooterProps;
 

--- a/packages/flat-components/src/components/RoomStatusElement/index.tsx
+++ b/packages/flat-components/src/components/RoomStatusElement/index.tsx
@@ -1,8 +1,7 @@
-import "./index.less";
-
 import React from "react";
-import { RoomInfo, RoomStatus } from "../../types/room";
 import { useTranslation } from "react-i18next";
+import { RoomInfo, RoomStatus } from "../../types/room";
+import "./index.less";
 
 export interface RoomStatusElementProps {
     room: RoomInfo;

--- a/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageContainer.stories.tsx
+++ b/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageContainer.stories.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { Story, Meta, ArgTypes } from "@storybook/react";
+import { ArgTypes, Meta, Story } from "@storybook/react";
+import { Modal } from "antd";
 import Chance from "chance";
 import faker from "faker";
-import { action, AnnotationsMap, makeObservable } from "mobx";
-import { Modal } from "antd";
-import { CloudStorageContainer, CloudStorageStore } from "./index";
+import { AnnotationsMap, action, makeObservable } from "mobx";
 import { CloudStorageUploadTask } from "../../components/CloudStorage/types";
+import { CloudStorageContainer, CloudStorageStore } from "./index";
 
 const chance = new Chance();
 

--- a/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageExternalFilePanel.tsx
+++ b/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageExternalFilePanel.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useEffect, useState, useRef } from "react";
-import { Form, Modal, Input, Select, message, FormInstance } from "antd";
+import React, { FC, useEffect, useRef, useState } from "react";
+import { Form, FormInstance, Input, Modal, Select, message } from "antd";
 import { useTranslation } from "react-i18next";
-import { CloudStorageStore } from "./store";
 import { useSafePromise } from "../../utils/hooks";
+import { CloudStorageStore } from "./store";
 
 interface FormValues {
     fileName: string;

--- a/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageFileListContainer.tsx
+++ b/packages/flat-components/src/containers/CloudStorageContainer/CloudStorageFileListContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { toJS } from "mobx";
 import { observer } from "mobx-react-lite";
-import { CloudStorageStore } from "./store";
 import { CloudStorageFileList } from "../../components/CloudStorage";
+import { CloudStorageStore } from "./store";
 
 export interface CloudStorageFileListContainerProps {
     store: CloudStorageStore;

--- a/packages/flat-components/src/containers/CloudStorageContainer/index.tsx
+++ b/packages/flat-components/src/containers/CloudStorageContainer/index.tsx
@@ -1,17 +1,16 @@
-import "./style.less";
-
 import React, { useCallback, useState } from "react";
-import { observer } from "mobx-react-lite";
-import { Button, Dropdown, Menu } from "antd";
 import { FormOutlined } from "@ant-design/icons";
-import { CSSTransition } from "react-transition-group";
-import { CloudStorageStore } from "./store";
-import { CloudStorageSkeletons, CloudStorageUploadPanel } from "../../components/CloudStorage";
-import { CloudStorageUploadListContainer } from "./CloudStorageUploadListContainer";
-import { CloudStorageFileListContainer } from "./CloudStorageFileListContainer";
+import { Button, Dropdown, Menu } from "antd";
 import classNames from "classnames";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { CSSTransition } from "react-transition-group";
+import { CloudStorageSkeletons, CloudStorageUploadPanel } from "../../components/CloudStorage";
 import { CloudStorageExternalFilePanel } from "./CloudStorageExternalFilePanel";
+import { CloudStorageFileListContainer } from "./CloudStorageFileListContainer";
+import { CloudStorageUploadListContainer } from "./CloudStorageUploadListContainer";
+import { CloudStorageStore } from "./store";
+import "./style.less";
 
 export * from "./store";
 

--- a/packages/flat-components/src/theme/antd.mod.stories.tsx
+++ b/packages/flat-components/src/theme/antd.mod.stories.tsx
@@ -1,11 +1,10 @@
-import "./antd.mod.stories.less";
-
 import React from "react";
-import { Story, Meta } from "@storybook/react";
-import { Input, Radio, Checkbox, Button, ButtonProps } from "antd";
 import { MessageOutlined } from "@ant-design/icons";
 import { useRef } from "@storybook/client-api";
+import { Meta, Story } from "@storybook/react";
+import { Button, ButtonProps, Checkbox, Input, Radio } from "antd";
 import faker from "faker";
+import "./antd.mod.stories.less";
 
 const storyMeta: Meta = {
     title: "Theme/AntdMod",
@@ -27,15 +26,15 @@ export const Buttons: Story = () => {
             <ButtonRow type="dashed">Dashed</ButtonRow>
             <ButtonRow type="text">Text</ButtonRow>
             <ButtonRow type="link">Link</ButtonRow>
-            <ButtonRow type="text" danger>
+            <ButtonRow danger type="text">
                 Danger
             </ButtonRow>
-            <ButtonRow type="default" danger>
+            <ButtonRow danger type="default">
                 Danger
             </ButtonRow>
-            <ButtonRow type="primary" shape="circle" icon={<MessageOutlined />}></ButtonRow>
-            <ButtonRow type="default" shape="circle" icon={<MessageOutlined />}></ButtonRow>
-            <ButtonRow type="dashed" shape="circle" icon={<MessageOutlined />}></ButtonRow>
+            <ButtonRow icon={<MessageOutlined />} shape="circle" type="primary"></ButtonRow>
+            <ButtonRow icon={<MessageOutlined />} shape="circle" type="default"></ButtonRow>
+            <ButtonRow icon={<MessageOutlined />} shape="circle" type="dashed"></ButtonRow>
             <div style={{ backgroundColor: "var(--grey-12)" }}>
                 <ButtonRow type="ghost">Ghost</ButtonRow>
             </div>

--- a/packages/flat-components/src/theme/colors.stories.tsx
+++ b/packages/flat-components/src/theme/colors.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
-import { Story, Meta } from "@storybook/react";
-import "./colors.less";
+import { Meta, Story } from "@storybook/react";
 import { useIsomorphicLayoutEffect } from "react-use";
+import "./colors.less";
 
 const storyMeta: Meta = {
     title: "Theme/Colors",

--- a/packages/flat-components/src/theme/theme.stories.tsx
+++ b/packages/flat-components/src/theme/theme.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
-import type { Story, Meta } from "@storybook/react";
-import "./colors.less";
+import { Meta, Story } from "@storybook/react";
 import { useIsomorphicLayoutEffect } from "react-use";
+import "./colors.less";
 
 const storyMeta: Meta = {
     title: "Theme/Colors",

--- a/packages/flat-components/src/utils/hooks.ts
+++ b/packages/flat-components/src/utils/hooks.ts
@@ -1,14 +1,14 @@
+import { DependencyList, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import {
-    computed,
     IComputedValue,
     IComputedValueOptions,
     IReactionOptions,
     IReactionPublic,
+    computed,
     observable,
     reaction,
 } from "mobx";
 import { useLocalObservable } from "mobx-react-lite";
-import { DependencyList, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 
 export function useIsUnMounted(): RefObject<boolean> {

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -26,6 +26,7 @@
     "eslint-config-react-app": "^6.0.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",

--- a/web/flat-web/scripts/vite-plugin-dotenv.ts
+++ b/web/flat-web/scripts/vite-plugin-dotenv.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import dotenvReal from "dotenv";
 import dotenvExpand from "dotenv-expand";
-import type { Plugin } from "vite";
+import { Plugin } from "vite";
 
 // based on https://github.com/IndexXuan/vite-plugin-env-compatible
 export function dotenv(envDir: string): Plugin {

--- a/web/flat-web/scripts/vite-plugin-html-hash.ts
+++ b/web/flat-web/scripts/vite-plugin-html-hash.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import type { Plugin } from "vite";
+import { Plugin } from "vite";
 
 export function injectHtmlHash(): Plugin {
     return {

--- a/web/flat-web/scripts/vite-plugin-inline-assets.ts
+++ b/web/flat-web/scripts/vite-plugin-inline-assets.ts
@@ -1,7 +1,7 @@
-import type { Plugin } from "vite";
 import { promises as fsp } from "fs";
-import mime from "mime/lite";
 import svgToTinyDataUri from "@netless/mini-svg-data-uri";
+import mime from "mime/lite";
+import { Plugin } from "vite";
 
 // e.g:
 // flat/node_modules/electron/index.js?v=19cea64f => flat/node_modules/electron/index.js

--- a/web/flat-web/scripts/vite-plugin-version.ts
+++ b/web/flat-web/scripts/vite-plugin-version.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import type { Plugin } from "vite";
+import { Plugin } from "vite";
 
 export function version(pkgPath: string): Plugin {
     return {

--- a/web/flat-web/src/AppRoutes/AppRouteContainer.tsx
+++ b/web/flat-web/src/AppRoutes/AppRouteContainer.tsx
@@ -1,14 +1,14 @@
-import loadable from "@loadable/component";
 import React, { ComponentType, useContext, useEffect } from "react";
+import loadable from "@loadable/component";
+import { FlatThemeBodyProvider, LoadingPage } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 import { RouteComponentProps } from "react-router-dom";
 import { useIsomorphicLayoutEffect } from "react-use";
-import { FlatThemeBodyProvider, LoadingPage } from "flat-components";
 import { ConfigStoreContext, PageStoreContext } from "../components/StoreProvider";
 import { RouteNameType } from "../route-config";
 import { AppRouteErrorBoundary } from "./AppRouteErrorBoundary";
 import { routePages } from "./route-pages";
-import { observer } from "mobx-react-lite";
 
 export interface AppRouteContainerProps {
     name: RouteNameType;

--- a/web/flat-web/src/AppRoutes/AppRouteErrorBoundary.tsx
+++ b/web/flat-web/src/AppRoutes/AppRouteErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType } from "react";
-import { RouteComponentProps } from "react-router-dom";
 import { ErrorPage } from "flat-components";
+import { RouteComponentProps } from "react-router-dom";
 
 export interface AppRouteErrorBoundaryProps {
     Comp: ComponentType<any>;

--- a/web/flat-web/src/api-middleware/CloudRecording.ts
+++ b/web/flat-web/src/api-middleware/CloudRecording.ts
@@ -1,16 +1,16 @@
 import { updateRecordEndTime } from "./flatServer";
 import {
-    cloudRecordAcquire,
-    CloudRecordStopResult,
-    cloudRecordStop,
     CloudRecordAcquirePayload,
-    CloudRecordStartPayload,
-    cloudRecordStart,
     CloudRecordQueryResult,
-    cloudRecordQuery,
-    cloudRecordUpdateLayout,
+    CloudRecordStartPayload,
+    CloudRecordStopResult,
     CloudRecordUpdateLayoutPayload,
     CloudRecordUpdateLayoutResult,
+    cloudRecordAcquire,
+    cloudRecordQuery,
+    cloudRecordStart,
+    cloudRecordStop,
+    cloudRecordUpdateLayout,
 } from "./flatServer/agora";
 
 /**

--- a/web/flat-web/src/api-middleware/Rtm.ts
+++ b/web/flat-web/src/api-middleware/Rtm.ts
@@ -1,11 +1,11 @@
 import AgoraRTM, { RtmChannel, RtmClient } from "agora-rtm-sdk";
+import { EventEmitter } from "eventemitter3";
 import polly from "polly-js";
 import { v4 as uuidv4 } from "uuid";
 import { AGORA, NODE_ENV } from "../constants/process";
-import { EventEmitter } from "eventemitter3";
-import { RoomStatus } from "./flatServer/constants";
-import { generateRTMToken } from "./flatServer/agora";
 import { globalStore } from "../stores/GlobalStore";
+import { generateRTMToken } from "./flatServer/agora";
+import { RoomStatus } from "./flatServer/constants";
 
 export interface RtmRESTfulQueryPayload {
     filter: {

--- a/web/flat-web/src/api-middleware/SmartPlayer.ts
+++ b/web/flat-web/src/api-middleware/SmartPlayer.ts
@@ -1,24 +1,24 @@
-import "video.js/dist/video-js.css";
-import "@netless/window-manager/dist/style.css";
 import CombinePlayerFactory, { CombinePlayer, PublicCombinedStatus } from "@netless/combine-player";
 import {
+    PluginContext as VideoJsPluginContext,
     PluginId as VideoJsPluginId,
     videoJsPlugin,
-    PluginContext as VideoJsPluginContext,
 } from "@netless/video-js-plugin";
+import { WindowManager } from "@netless/window-manager";
 import { EventEmitter } from "eventemitter3";
+import { Region } from "flat-components";
 import polly from "polly-js";
 import {
-    createPlugins,
     PlayableCheckingParams,
     Player,
     PlayerPhase,
     ReplayRoomParams,
     WhiteWebSdk,
+    createPlugins,
 } from "white-web-sdk";
-import { Region } from "flat-components";
 import { NETLESS, NODE_ENV } from "../constants/process";
-import { WindowManager } from "@netless/window-manager";
+import "@netless/window-manager/dist/style.css";
+import "video.js/dist/video-js.css";
 
 export enum SmartPlayerEventType {
     Ready = "Ready",

--- a/web/flat-web/src/api-middleware/flatServer/utils.ts
+++ b/web/flat-web/src/api-middleware/flatServer/utils.ts
@@ -1,8 +1,8 @@
 import Axios, { AxiosRequestConfig } from "axios";
-import { globalStore } from "../../stores/GlobalStore";
-import { FLAT_SERVER_VERSIONS, Status } from "./constants";
-import { ServerRequestError } from "../../utils/error/server-request-error";
 import { RequestErrorCode } from "../../constants/error-code";
+import { globalStore } from "../../stores/GlobalStore";
+import { ServerRequestError } from "../../utils/error/server-request-error";
+import { FLAT_SERVER_VERSIONS, Status } from "./constants";
 
 export type FlatServerResponse<T> =
     | {

--- a/web/flat-web/src/api-middleware/rtc/avatar.ts
+++ b/web/flat-web/src/api-middleware/rtc/avatar.ts
@@ -1,4 +1,4 @@
-import type {
+import {
     IAgoraRTCClient,
     IAgoraRTCRemoteUser,
     ICameraVideoTrack,
@@ -8,8 +8,8 @@ import type {
     ITrack,
 } from "agora-rtc-sdk-ng";
 import { EventEmitter } from "eventemitter3";
-import type { User } from "../../stores/user-store";
-import type { RtcRoom } from "./room";
+import { User } from "../../stores/user-store";
+import { RtcRoom } from "./room";
 
 export interface RtcAvatarParams {
     rtc: RtcRoom;

--- a/web/flat-web/src/api-middleware/rtc/room.ts
+++ b/web/flat-web/src/api-middleware/rtc/room.ts
@@ -1,4 +1,4 @@
-import type {
+import AgoraRTC, {
     IAgoraRTCClient,
     IAgoraRTCRemoteUser,
     ICameraVideoTrack,
@@ -6,15 +6,12 @@ import type {
     ILocalVideoTrack,
     IMicrophoneAudioTrack,
 } from "agora-rtc-sdk-ng";
-import type { RtcAvatar } from "./avatar";
-import type { Disposer } from "./hot-plug";
-
-import AgoraRTC from "agora-rtc-sdk-ng";
 import { AGORA } from "../../constants/process";
+import { configStore } from "../../stores/config-store";
 import { globalStore } from "../../stores/GlobalStore";
 import { generateRTCToken } from "../flatServer/agora";
-import { setCameraTrack, setMicrophoneTrack, hotPlug } from "./hot-plug";
-import { configStore } from "../../stores/config-store";
+import { RtcAvatar } from "./avatar";
+import { Disposer, hotPlug, setCameraTrack, setMicrophoneTrack } from "./hot-plug";
 
 AgoraRTC.enableLogUpload();
 

--- a/web/flat-web/src/api-middleware/rtc/share-screen.ts
+++ b/web/flat-web/src/api-middleware/rtc/share-screen.ts
@@ -1,8 +1,7 @@
-import AgoraRTC, { IAgoraRTCClient } from "agora-rtc-sdk-ng";
-import type { ILocalVideoTrack } from "agora-rtc-sdk-ng";
+import AgoraRTC, { IAgoraRTCClient, ILocalVideoTrack } from "agora-rtc-sdk-ng";
+import EventEmitter from "eventemitter3";
 import { AGORA } from "../../constants/process";
 import { globalStore } from "../../stores/GlobalStore";
-import EventEmitter from "eventemitter3";
 
 export class RTCShareScreen {
     public shareScreenClient?: IAgoraRTCClient;

--- a/web/flat-web/src/components/AppStoreButton/AppButton.tsx
+++ b/web/flat-web/src/components/AppStoreButton/AppButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
+import { LoadingOutlined } from "@ant-design/icons";
 import { observer } from "mobx-react-lite";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
-import { LoadingOutlined } from "@ant-design/icons";
 
 export interface AppButtonProps {
     kind: string;

--- a/web/flat-web/src/components/AppStoreButton/index.tsx
+++ b/web/flat-web/src/components/AppStoreButton/index.tsx
@@ -1,18 +1,16 @@
-import "./style.less";
+import React, { useState } from "react";
+import { AddAppParams } from "@netless/window-manager";
+import { Modal } from "antd";
+import { TopBarRightBtn, useSafePromise } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import appStoreSVG from "../../assets/image/app-store.svg";
+import cocosSVG from "../../assets/image/cocos.svg";
 import codeEditorSVG from "../../assets/image/code-editor.svg";
 import countdownSVG from "../../assets/image/countdown.svg";
 import geogebraSVG from "../../assets/image/geogebra.svg";
-import cocosSVG from "../../assets/image/cocos.svg";
-
-import React, { useState } from "react";
-import { observer } from "mobx-react-lite";
-import { Modal } from "antd";
-
-import { AddAppParams } from "@netless/window-manager";
-import { TopBarRightBtn, useSafePromise } from "flat-components";
 import { AppButton } from "./AppButton";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export interface AppStoreButtonProps {
     addApp: (config: AddAppParams) => Promise<void>;

--- a/web/flat-web/src/components/AvatarCanvas.tsx
+++ b/web/flat-web/src/components/AvatarCanvas.tsx
@@ -1,13 +1,11 @@
-import "./AvatarCanvas.less";
-
 import React, { useEffect, useState } from "react";
 import { message } from "antd";
 import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
-
 import { RtcAvatar, RtcEvents } from "../api-middleware/rtc/avatar";
 import { RtcRoom } from "../api-middleware/rtc/room";
 import { User } from "../stores/class-room-store";
+import "./AvatarCanvas.less";
 
 export interface AvatarCanvasProps {
     isCreator: boolean;

--- a/web/flat-web/src/components/ChatPanel/index.tsx
+++ b/web/flat-web/src/components/ChatPanel/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { ChatPanel as ChatPanelImpl, useComputed } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { ClassRoomStore } from "../../stores/class-room-store";
 import { generateAvatar } from "../../utils/generate-avatar";
 

--- a/web/flat-web/src/components/ChatPanelReplay/ChatMessageListReplay.tsx
+++ b/web/flat-web/src/components/ChatPanelReplay/ChatMessageListReplay.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Observer, observer } from "mobx-react-lite";
 import { ChatMessage } from "flat-components";
+import { Observer, observer } from "mobx-react-lite";
 import {
     AutoSizer,
     CellMeasurer,

--- a/web/flat-web/src/components/ChatPanelReplay/ChatMessagesReplay.tsx
+++ b/web/flat-web/src/components/ChatPanelReplay/ChatMessagesReplay.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { ChatMessageListReplay } from "./ChatMessageListReplay";
-import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { useTranslation } from "react-i18next";
+import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
+import { ChatMessageListReplay } from "./ChatMessageListReplay";
 
 export interface ChatMessagesReplayProps {
     classRoomReplayStore: ClassRoomReplayStore;

--- a/web/flat-web/src/components/ChatPanelReplay/index.tsx
+++ b/web/flat-web/src/components/ChatPanelReplay/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Tabs } from "antd";
 import { observer } from "mobx-react-lite";
-import { ChatMessagesReplay } from "./ChatMessagesReplay";
-import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { useTranslation } from "react-i18next";
+import { ClassRoomReplayStore } from "../../stores/class-room-replay-store";
+import { ChatMessagesReplay } from "./ChatMessagesReplay";
 
 export interface ChatPanelReplayProps {
     classRoomReplayStore: ClassRoomReplayStore;

--- a/web/flat-web/src/components/ClassRoom/RoomStatusStoppedModal.tsx
+++ b/web/flat-web/src/components/ClassRoom/RoomStatusStoppedModal.tsx
@@ -1,6 +1,6 @@
+import React, { useCallback } from "react";
 import { RoomStoppedModal } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback } from "react";
 import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RouteNameType, usePushHistory } from "../../utils/routes";
 

--- a/web/flat-web/src/components/CloudStorageButton.tsx
+++ b/web/flat-web/src/components/CloudStorageButton.tsx
@@ -1,14 +1,13 @@
 // TODO: remove this component when multi sub window is Done
-import cloudStorageSVG from "../assets/image/cloud-storage.svg";
-
+import React, { useCallback } from "react";
 import { Modal } from "antd";
 import { TopBarRightBtn } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import cloudStorageSVG from "../assets/image/cloud-storage.svg";
 import { CloudStoragePanel } from "../pages/CloudStoragePage/CloudStoragePanel";
 import { ClassRoomStore } from "../stores/class-room-store";
 import "./CloudStorageButton.less";
-import { useTranslation } from "react-i18next";
 
 interface CloudStorageButtonProps {
     classroom: ClassRoomStore;

--- a/web/flat-web/src/components/EditRoomPage/index.tsx
+++ b/web/flat-web/src/components/EditRoomPage/index.tsx
@@ -1,12 +1,10 @@
-import "./style.less";
-
-import React, { useEffect } from "react";
-import { observer } from "mobx-react-lite";
+import React, { useContext, useEffect } from "react";
 import { EditRoomBody, EditRoomBodyProps } from "flat-components";
-import { useHistory } from "react-router";
-import { useContext } from "react";
-import { PageStoreContext } from "../StoreProvider";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router";
+import { PageStoreContext } from "../StoreProvider";
+import "./style.less";
 
 export type EditRoomPageProps = EditRoomBodyProps;
 

--- a/web/flat-web/src/components/ExitRoomConfirm.tsx
+++ b/web/flat-web/src/components/ExitRoomConfirm.tsx
@@ -1,10 +1,10 @@
+import React, { useCallback, useState } from "react";
 import {
     CloseRoomConfirmModal,
     ExitRoomConfirmModal,
     StopClassConfirmModal,
 } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback, useState } from "react";
 import { RoomStatus } from "../api-middleware/flatServer/constants";
 import { useSafePromise } from "../utils/hooks/lifecycle";
 import { RouteNameType, usePushHistory } from "../utils/routes";

--- a/web/flat-web/src/components/InviteButton.tsx
+++ b/web/flat-web/src/components/InviteButton.tsx
@@ -1,11 +1,10 @@
-import inviteSVG from "../assets/image/invite.svg";
-
 import React, { useState } from "react";
+import { TopBarRightBtn } from "flat-components";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import inviteSVG from "../assets/image/invite.svg";
 import { RoomItem } from "../stores/room-store";
 import { InviteModal } from "./Modal/InviteModal";
-import { TopBarRightBtn } from "flat-components";
-import { useTranslation } from "react-i18next";
 
 export interface InviteButtonProps {
     roomInfo?: RoomItem;

--- a/web/flat-web/src/components/MainPageLayout.tsx
+++ b/web/flat-web/src/components/MainPageLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { observer } from "mobx-react-lite";
-import { MainPageLayoutHorizontalContainer } from "./MainPageLayoutHorizontalContainer";
 import { routePages } from "../AppRoutes/route-pages";
+import { MainPageLayoutHorizontalContainer } from "./MainPageLayoutHorizontalContainer";
 import { PageStoreContext } from "./StoreProvider";
 
 export const MainPageLayout = observer(function MainPageLayout({ children }) {

--- a/web/flat-web/src/components/MainPageLayoutHorizontalContainer/index.tsx
+++ b/web/flat-web/src/components/MainPageLayoutHorizontalContainer/index.tsx
@@ -1,20 +1,20 @@
 /* eslint react/display-name: off */
 // import deviceSVG from "./icons/device.svg";
 // import deviceActiveSVG from "./icons/device-active.svg";
-import downloadSVG from "./icons/download.svg";
-import settingSVG from "./icons/setting.svg";
-import gitHubSVG from "./icons/github.svg";
-import feedbackSVG from "./icons/feedback.svg";
-import logoutSVG from "./icons/logout.svg";
 
 import React, { useContext } from "react";
-import { useHistory, useLocation } from "react-router-dom";
 import { MainPageLayoutHorizontal, MainPageLayoutItem, MainPageLayoutProps } from "flat-components";
 import { useTranslation } from "react-i18next";
-import { routeConfig, RouteNameType } from "../../route-config";
-import { GlobalStoreContext } from "../StoreProvider";
-import { generateAvatar } from "../../utils/generate-avatar";
+import { useHistory, useLocation } from "react-router-dom";
 import { FLAT_DOWNLOAD_URL } from "../../constants/process";
+import { RouteNameType, routeConfig } from "../../route-config";
+import { generateAvatar } from "../../utils/generate-avatar";
+import { GlobalStoreContext } from "../StoreProvider";
+import downloadSVG from "./icons/download.svg";
+import feedbackSVG from "./icons/feedback.svg";
+import gitHubSVG from "./icons/github.svg";
+import logoutSVG from "./icons/logout.svg";
+import settingSVG from "./icons/setting.svg";
 
 export interface MainPageLayoutHorizontalContainerProps {
     subMenu?: MainPageLayoutItem[];

--- a/web/flat-web/src/components/Modal/ExitReplayConfirmModal.tsx
+++ b/web/flat-web/src/components/Modal/ExitReplayConfirmModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal } from "antd";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 
 interface ExitReplayConfirmModalProps {

--- a/web/flat-web/src/components/Modal/InviteModal.tsx
+++ b/web/flat-web/src/components/Modal/InviteModal.tsx
@@ -1,14 +1,13 @@
-import "./InviteModal.less";
-
 import React, { useCallback, useContext, useEffect } from "react";
-import { observer } from "mobx-react-lite";
 import { message } from "antd";
 import { InviteModal as InviteModalImpl } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { RoomItem } from "../../stores/room-store";
 import { GlobalStoreContext, RoomStoreContext } from "../StoreProvider";
 import { errorTips } from "../Tips/ErrorTips";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
+import "./InviteModal.less";
 
 export interface InviteModalProps {
     visible: boolean;

--- a/web/flat-web/src/components/Modal/RemoveHistoryRoomModal.tsx
+++ b/web/flat-web/src/components/Modal/RemoveHistoryRoomModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { observer } from "mobx-react-lite";
 import { Button, Modal } from "antd";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 
 interface RemoveHistoryRoomModalProps {

--- a/web/flat-web/src/components/RealtimePanel.tsx
+++ b/web/flat-web/src/components/RealtimePanel.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import classNames from "classnames";
-
 import "./RealtimePanel.less";
 
 export type RealtimePanelProps = {

--- a/web/flat-web/src/components/ShareScreen/index.tsx
+++ b/web/flat-web/src/components/ShareScreen/index.tsx
@@ -1,12 +1,11 @@
-import "./style.less";
-
 import React, { useEffect, useMemo, useRef } from "react";
-import { observer } from "mobx-react-lite";
-import classNames from "classnames";
-import type { ShareScreenStore } from "../../stores/share-screen-store";
 import { message } from "antd";
-import { shareScreenEvents } from "../../api-middleware/rtc/share-screen";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { shareScreenEvents } from "../../api-middleware/rtc/share-screen";
+import { ShareScreenStore } from "../../stores/share-screen-store";
+import "./style.less";
 
 interface ShareScreenProps {
     shareScreenStore: ShareScreenStore;

--- a/web/flat-web/src/components/StoreProvider.tsx
+++ b/web/flat-web/src/components/StoreProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC } from "react";
+import React, { FC, createContext } from "react";
 import { configStore } from "../stores/config-store";
 import { globalStore } from "../stores/GlobalStore";
 import { pageStore } from "../stores/page-store";

--- a/web/flat-web/src/components/Tips/ErrorTips.tsx
+++ b/web/flat-web/src/components/Tips/ErrorTips.tsx
@@ -1,6 +1,6 @@
 import { message } from "antd";
-import { ServerRequestError } from "../../utils/error/server-request-error";
 import { NODE_ENV } from "../../constants/process";
+import { ServerRequestError } from "../../utils/error/server-request-error";
 import { i18n } from "../../utils/i18n";
 
 export const errorTips = (e: unknown): void => {

--- a/web/flat-web/src/components/TopBarRightBtn/index.tsx
+++ b/web/flat-web/src/components/TopBarRightBtn/index.tsx
@@ -1,13 +1,12 @@
-import { TopBarRightBtn as TopBarRightBtnImpl } from "flat-components";
 import React, { ReactElement } from "react";
-
+import { TopBarRightBtn as TopBarRightBtnImpl } from "flat-components";
 import exitSVG from "./icons/exit.svg";
 import followActiveSVG from "./icons/follow-active.svg";
 import followSVG from "./icons/follow.svg";
 import hideSideActiveSVG from "./icons/hide-side-active.svg";
 import hideSideSVG from "./icons/hide-side.svg";
-import shareScreenSVG from "./icons/share-screen.svg";
 import shareScreenActiveSVG from "./icons/share-screen-active.svg";
+import shareScreenSVG from "./icons/share-screen.svg";
 
 const Icons = {
     exit: exitSVG,

--- a/web/flat-web/src/components/TopBarRoundBtn/index.tsx
+++ b/web/flat-web/src/components/TopBarRoundBtn/index.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from "react";
+import { TopBarRoundBtn as TopBarRoundBtnImpl } from "flat-components";
+import classBeginSVG from "./icons/class-begin.svg";
+import classInteractionSVG from "./icons/class-interaction.svg";
+import classLectureSVG from "./icons/class-lecture.svg";
+import classPauseSVG from "./icons/class-pause.svg";
+import classResumeSVG from "./icons/class-resume.svg";
+import classStopSVG from "./icons/class-stop.svg";
+
+const Icons = {
+    "class-begin": classBeginSVG,
+    "class-interaction": classInteractionSVG,
+    "class-lecture": classLectureSVG,
+    "class-pause": classPauseSVG,
+    "class-resume": classResumeSVG,
+    "class-stop": classStopSVG,
+};
+
+export interface TopBarRoundBtnProps extends React.HTMLAttributes<HTMLButtonElement> {
+    dark?: boolean;
+    /** file name (without .ext) in src/assets/image/ */
+    iconName: keyof typeof Icons;
+}
+
+export function TopBarRoundBtn({
+    dark,
+    iconName,
+    ...restProps
+}: TopBarRoundBtnProps): ReactElement {
+    return <TopBarRoundBtnImpl {...restProps} dark={dark} icon={<img src={Icons[iconName]} />} />;
+}

--- a/web/flat-web/src/components/Whiteboard.tsx
+++ b/web/flat-web/src/components/Whiteboard.tsx
@@ -1,20 +1,20 @@
-import "@netless/window-manager/dist/style.css";
-import "./Whiteboard.less";
-
+import React, { useCallback, useEffect, useState } from "react";
 import RedoUndo from "@netless/redo-undo";
 import ToolBox from "@netless/tool-box";
 import { WindowManager } from "@netless/window-manager";
+import { message } from "antd";
 import classNames from "classnames";
 import { RaiseHand, ScenesController } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback, useEffect, useState } from "react";
-import { message } from "antd";
 import { useTranslation } from "react-i18next";
 import { RoomPhase } from "white-web-sdk";
+import { ClassRoomStore } from "../stores/class-room-store";
 import { WhiteboardStore } from "../stores/whiteboard-store";
 import { isSupportedFileExt } from "../utils/drag-and-drop";
 import { isSupportedImageType, onDropImage } from "../utils/drag-and-drop/image";
-import { ClassRoomStore } from "../stores/class-room-store";
+import "@netless/window-manager/dist/style.css";
+// eslint-disable-next-line import/order
+import "./Whiteboard.less";
 
 export interface WhiteboardProps {
     whiteboardStore: WhiteboardStore;

--- a/web/flat-web/src/pages/BigClassPage/BigClassAvatar.tsx
+++ b/web/flat-web/src/pages/BigClassPage/BigClassAvatar.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import { BigVideoAvatar } from "flat-components";
 import { VideoAvatarProps } from "flat-components/src/components/ClassroomPage/VideoAvatar";
-import React from "react";
 import { RtcRoom } from "../../api-middleware/rtc/room";
 import { AvatarCanvas } from "../../components/AvatarCanvas";
 import { User } from "../../stores/user-store";

--- a/web/flat-web/src/pages/BigClassPage/index.tsx
+++ b/web/flat-web/src/pages/BigClassPage/index.tsx
@@ -1,24 +1,23 @@
-import "./BigClassPage.less";
-
+import React, { useEffect, useRef, useState } from "react";
 import { message } from "antd";
 import classNames from "classnames";
 import {
     CloudRecordBtn,
-    Timer,
     LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
 } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { RoomPhase } from "white-web-sdk";
-import { useTranslation } from "react-i18next";
 import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
 import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RtcChannelType } from "../../api-middleware/rtc/room";
+import { AppStoreButton } from "../../components/AppStoreButton";
 import { ChatPanel } from "../../components/ChatPanel";
 import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
 import { CloudStorageButton } from "../../components/CloudStorageButton";
@@ -29,16 +28,16 @@ import {
 } from "../../components/ExitRoomConfirm";
 import InviteButton from "../../components/InviteButton";
 import { RealtimePanel } from "../../components/RealtimePanel";
+import { ShareScreen } from "../../components/ShareScreen";
 import { TopBarRightBtn } from "../../components/TopBarRightBtn";
 import { Whiteboard } from "../../components/Whiteboard";
-import { RecordingConfig, useClassRoomStore, User } from "../../stores/class-room-store";
+import { RecordingConfig, User, useClassRoomStore } from "../../stores/class-room-store";
+import { generateAvatar } from "../../utils/generate-avatar";
 import { useAutoRun, useReaction } from "../../utils/mobx";
 import { RouteNameType, RouteParams } from "../../utils/routes";
 import { runtime } from "../../utils/runtime";
 import { BigClassAvatar } from "./BigClassAvatar";
-import { ShareScreen } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
+import "./BigClassPage.less";
 
 const recordingConfig: RecordingConfig = Object.freeze({
     channelType: RtcChannelType.Broadcast,

--- a/web/flat-web/src/pages/CloudStoragePage/CloudStoragePanel.tsx
+++ b/web/flat-web/src/pages/CloudStoragePage/CloudStoragePanel.tsx
@@ -1,9 +1,8 @@
-import "./style.less";
-
+import React, { useEffect } from "react";
 import { CloudStorageContainer } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useEffect } from "react";
 import { CloudStorageStore } from "./store";
+import "./style.less";
 
 export interface CloudStoragePanelProps {
     cloudStorage: CloudStorageStore;

--- a/web/flat-web/src/pages/CloudStoragePage/index.tsx
+++ b/web/flat-web/src/pages/CloudStoragePage/index.tsx
@@ -1,15 +1,15 @@
-import "./style.less";
 import React, { useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { CloudStorageContainer } from "flat-components";
-import { PageStoreContext } from "../../components/StoreProvider";
-import { CloudStorageStore } from "./store";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
 import { loginCheck } from "../../api-middleware/flatServer";
-import { ServerRequestError } from "../../utils/error/server-request-error";
+import { PageStoreContext } from "../../components/StoreProvider";
 import { RequestErrorCode } from "../../constants/error-code";
 import { RouteNameType } from "../../route-config";
+import { ServerRequestError } from "../../utils/error/server-request-error";
 import { useReplaceHistory } from "../../utils/routes";
+import { CloudStorageStore } from "./store";
+import "./style.less";
 
 export interface CloudStoragePageProps {}
 

--- a/web/flat-web/src/pages/CloudStoragePage/store.tsx
+++ b/web/flat-web/src/pages/CloudStoragePage/store.tsx
@@ -1,8 +1,9 @@
+import React, { ReactNode } from "react";
 import { Modal } from "antd";
 import {
     CloudStorageConvertStatusType,
-    CloudStorageFile as CloudStorageFileUI,
     CloudStorageFileName,
+    CloudStorageFile as CloudStorageFileUI,
     CloudStorageStore as CloudStorageStoreBase,
     CloudStorageUploadStatusType,
     CloudStorageUploadTask,
@@ -11,28 +12,27 @@ import {
 } from "flat-components";
 import { i18n } from "i18next";
 import { action, computed, makeObservable, observable, reaction, runInAction } from "mobx";
-import React, { ReactNode } from "react";
-import { queryH5ConvertingStatus } from "../../api-middleware/h5-converting";
-import { getFileExt, isPPTX } from "../../utils/file";
 import {
     ConvertingTaskStatus,
     queryConvertingTaskStatus,
 } from "../../api-middleware/courseware-converting";
 import { FileConvertStep } from "../../api-middleware/flatServer/constants";
 import {
-    addExternalFile,
     CloudFile,
+    addExternalFile,
     convertFinish,
     convertStart,
     listFiles,
-    removeFiles,
     removeExternalFiles,
-    renameFile,
+    removeFiles,
     renameExternalFile,
+    renameFile,
 } from "../../api-middleware/flatServer/storage";
+import { queryH5ConvertingStatus } from "../../api-middleware/h5-converting";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { coursewarePreloader } from "../../utils/courseware-preloader";
+import { getFileExt, isPPTX } from "../../utils/file";
 import { getUploadTaskManager } from "../../utils/upload-task-manager";
 import { UploadStatusType, UploadTask } from "../../utils/upload-task-manager/upload-task";
 import { ConvertStatusManager } from "./ConvertStatusManager";

--- a/web/flat-web/src/pages/DevicesTestPage/index.tsx
+++ b/web/flat-web/src/pages/DevicesTestPage/index.tsx
@@ -1,15 +1,13 @@
-import "./style.less";
-
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { DeviceTestPanel } from "flat-components";
 import { observer } from "mobx-react-lite";
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
-
-import { DeviceTest } from "../../api-middleware/rtc/device-test";
 import { useParams } from "react-router-dom";
-import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
-import { joinRoomHandler } from "../utils/join-room-handler";
+import { DeviceTest } from "../../api-middleware/rtc/device-test";
 import { GlobalStoreContext } from "../../components/StoreProvider";
 import { configStore } from "../../stores/config-store";
+import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
+import { joinRoomHandler } from "../utils/join-room-handler";
+import "./style.less";
 
 export const DevicesTestPage = observer(function DeviceTestPage() {
     const pushHistory = usePushHistory();

--- a/web/flat-web/src/pages/HomePage/MainRoomHistoryPanel/index.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomHistoryPanel/index.tsx
@@ -1,11 +1,11 @@
 // import "../MainRoomListPanel/MainRoomList.less";
 
 import React from "react";
-import { observer } from "mobx-react-lite";
-import { MainRoomList } from "../MainRoomListPanel/MainRoomList";
-import { ListRoomsType } from "../../../api-middleware/flatServer";
 import { RoomList } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { MainRoomList } from "../MainRoomListPanel/MainRoomList";
 
 export const MainRoomHistoryPanel = observer<{ isLogin: boolean }>(function MainRoomHistoryPanel({
     isLogin,

--- a/web/flat-web/src/pages/HomePage/MainRoomListPanel/MainRoomList.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomListPanel/MainRoomList.tsx
@@ -1,6 +1,5 @@
-import { message } from "antd";
 import React, { Fragment, useCallback, useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
+import { message } from "antd";
 import { isSameDay } from "date-fns";
 import {
     InviteModal,
@@ -14,16 +13,17 @@ import {
     RoomListSkeletons,
     RoomStatusType,
 } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { ListRoomsType } from "../../../api-middleware/flatServer";
 import { RoomStatus, RoomType } from "../../../api-middleware/flatServer/constants";
 import { GlobalStoreContext, RoomStoreContext } from "../../../components/StoreProvider";
 import { errorTips } from "../../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../../constants/process";
 import { RoomItem } from "../../../stores/room-store";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
 import { RouteNameType, usePushHistory } from "../../../utils/routes";
 import { joinRoomHandler } from "../../utils/join-room-handler";
-import { FLAT_WEB_BASE_URL } from "../../../constants/process";
-import { useTranslation } from "react-i18next";
 
 export interface MainRoomListProps {
     listRoomsType: ListRoomsType;

--- a/web/flat-web/src/pages/HomePage/MainRoomListPanel/index.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomListPanel/index.tsx
@@ -1,11 +1,10 @@
-import "./style.less";
-
 import React, { useMemo, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { RoomList } from "flat-components";
-import { MainRoomList } from "./MainRoomList";
-import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { ListRoomsType } from "../../../api-middleware/flatServer";
+import { MainRoomList } from "./MainRoomList";
+import "./style.less";
 
 export const MainRoomListPanel = observer<{ isLogin: boolean }>(function MainRoomListPanel({
     isLogin,

--- a/web/flat-web/src/pages/HomePage/MainRoomMenu/CreateRoomBox.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomMenu/CreateRoomBox.tsx
@@ -1,14 +1,13 @@
-import createSVG from "../../../assets/image/creat.svg";
-import "./CreateRoomBox.less";
-
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { Button, Checkbox, Dropdown, Form, Input, Menu, Modal } from "antd";
+import { ClassPicker, Region, RegionSVG, regions } from "flat-components";
 import { observer } from "mobx-react-lite";
-import { Button, Input, Modal, Checkbox, Form, Dropdown, Menu } from "antd";
+import { useTranslation } from "react-i18next";
 import { RoomType } from "../../../api-middleware/flatServer/constants";
+import createSVG from "../../../assets/image/creat.svg";
 import { ConfigStoreContext, GlobalStoreContext } from "../../../components/StoreProvider";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { ClassPicker, Region, regions, RegionSVG } from "flat-components";
-import { useTranslation } from "react-i18next";
+import "./CreateRoomBox.less";
 
 interface CreateRoomFormValues {
     roomTitle: string;

--- a/web/flat-web/src/pages/HomePage/MainRoomMenu/JoinRoomBox.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomMenu/JoinRoomBox.tsx
@@ -1,13 +1,12 @@
-import joinSVG from "../../../assets/image/join.svg";
-import "./JoinRoomBox.less";
-
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { Button, Checkbox, Form, Input, Modal } from "antd";
 import { observer } from "mobx-react-lite";
-import { Button, Input, Modal, Checkbox, Form } from "antd";
+import { useTranslation } from "react-i18next";
 import { validate, version } from "uuid";
+import joinSVG from "../../../assets/image/join.svg";
 import { ConfigStoreContext } from "../../../components/StoreProvider";
 import { useSafePromise } from "../../../utils/hooks/lifecycle";
-import { useTranslation } from "react-i18next";
+import "./JoinRoomBox.less";
 
 interface JoinRoomFormValues {
     roomUUID: string;

--- a/web/flat-web/src/pages/HomePage/MainRoomMenu/ScheduleRoomBox.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomMenu/ScheduleRoomBox.tsx
@@ -1,9 +1,8 @@
-import bookSVG from "../../../assets/image/book.svg";
-
 import React from "react";
 import { Button } from "antd";
-import { RouteNameType, usePushHistory } from "../../../utils/routes";
 import { useTranslation } from "react-i18next";
+import bookSVG from "../../../assets/image/book.svg";
+import { RouteNameType, usePushHistory } from "../../../utils/routes";
 
 export const ScheduleRoomBox = React.memo<{}>(function ScheduleRoomBox() {
     const { t } = useTranslation();

--- a/web/flat-web/src/pages/HomePage/MainRoomMenu/index.tsx
+++ b/web/flat-web/src/pages/HomePage/MainRoomMenu/index.tsx
@@ -1,15 +1,14 @@
-import "./MainRoomMenu.less";
-
 import React, { FC, useContext } from "react";
 import { Region } from "flat-components";
 import { RoomType } from "../../../api-middleware/flatServer/constants";
 import { GlobalStoreContext, RoomStoreContext } from "../../../components/StoreProvider";
+import { errorTips } from "../../../components/Tips/ErrorTips";
 import { RouteNameType, usePushHistory } from "../../../utils/routes";
+import { joinRoomHandler } from "../../utils/join-room-handler";
 import { CreateRoomBox } from "./CreateRoomBox";
 import { JoinRoomBox } from "./JoinRoomBox";
 import { ScheduleRoomBox } from "./ScheduleRoomBox";
-import { joinRoomHandler } from "../../utils/join-room-handler";
-import { errorTips } from "../../../components/Tips/ErrorTips";
+import "./MainRoomMenu.less";
 
 export const MainRoomMenu: FC = () => {
     const roomStore = useContext(RoomStoreContext);

--- a/web/flat-web/src/pages/HomePage/index.tsx
+++ b/web/flat-web/src/pages/HomePage/index.tsx
@@ -1,14 +1,13 @@
-import "./style.less";
-
 import React, { useContext, useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { MainRoomMenu } from "./MainRoomMenu";
-import { MainRoomListPanel } from "./MainRoomListPanel";
-import { MainRoomHistoryPanel } from "./MainRoomHistoryPanel";
-import { RouteNameType, useReplaceHistory } from "../../utils/routes";
-import { GlobalStoreContext, PageStoreContext } from "../../components/StoreProvider";
 import { loginCheck } from "../../api-middleware/flatServer";
+import { GlobalStoreContext, PageStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { RouteNameType, useReplaceHistory } from "../../utils/routes";
+import { MainRoomHistoryPanel } from "./MainRoomHistoryPanel";
+import { MainRoomListPanel } from "./MainRoomListPanel";
+import { MainRoomMenu } from "./MainRoomMenu";
+import "./style.less";
 
 export const HomePage = observer(function HomePage() {
     const replaceHistory = useReplaceHistory();

--- a/web/flat-web/src/pages/JoinPage/JoinPageDesktop.tsx
+++ b/web/flat-web/src/pages/JoinPage/JoinPageDesktop.tsx
@@ -1,14 +1,12 @@
 /* eslint react/jsx-no-target-blank: off */
-import logoSVG from "./icons/logo.svg";
-import downloadSVG from "./icons/download.svg";
-import joinSVG from "./icons/join.svg";
-
 import React, { useMemo } from "react";
 import { Avatar, Button } from "antd";
 import { useTranslation } from "react-i18next";
-
-import { RouteNameType, usePushHistory } from "../../utils/routes";
 import { FLAT_DOWNLOAD_URL } from "../../constants/process";
+import { RouteNameType, usePushHistory } from "../../utils/routes";
+import downloadSVG from "./icons/download.svg";
+import joinSVG from "./icons/join.svg";
+import logoSVG from "./icons/logo.svg";
 
 export interface JoinPageDesktopProps {
     isLogin: boolean;

--- a/web/flat-web/src/pages/JoinPage/JoinPageMobile.tsx
+++ b/web/flat-web/src/pages/JoinPage/JoinPageMobile.tsx
@@ -1,9 +1,8 @@
-import logoSVG from "./icons/logo-sm.svg";
-import openInBrowserSVG from "./icons/open-in-browser.svg";
-
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { FLAT_DOWNLOAD_URL } from "../../constants/process";
+import logoSVG from "./icons/logo-sm.svg";
+import openInBrowserSVG from "./icons/open-in-browser.svg";
 
 export interface JoinPageMobileProps {
     roomUUID: string;

--- a/web/flat-web/src/pages/JoinPage/index.tsx
+++ b/web/flat-web/src/pages/JoinPage/index.tsx
@@ -1,18 +1,16 @@
-import "./style.less";
-
 import React, { useContext, useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 import { useWindowSize } from "react-use";
-
-import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
-import { GlobalStoreContext, PageStoreContext } from "../../components/StoreProvider";
 import { loginCheck } from "../../api-middleware/flatServer";
-import { joinRoomHandler } from "../utils/join-room-handler";
+import { GlobalStoreContext, PageStoreContext } from "../../components/StoreProvider";
 import { PRIVACY_URL, PRIVACY_URL_CN, SERVICE_URL, SERVICE_URL_CN } from "../../constants/process";
+import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
+import { joinRoomHandler } from "../utils/join-room-handler";
 import JoinPageDesktop from "./JoinPageDesktop";
 import JoinPageMobile from "./JoinPageMobile";
+import "./style.less";
 
 export const JoinPage = observer(function JoinPage() {
     const { i18n } = useTranslation();

--- a/web/flat-web/src/pages/LoginPage/WeChatLogin.tsx
+++ b/web/flat-web/src/pages/LoginPage/WeChatLogin.tsx
@@ -1,20 +1,19 @@
-import "./WeChatLogin.less";
-
 import React, { useContext, useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
 import { LoadingOutlined } from "@ant-design/icons";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
-import { UserInfo } from "../../stores/GlobalStore";
 import { loginProcess, setAuthUUID } from "../../api-middleware/flatServer";
 import { FLAT_SERVER_LOGIN } from "../../api-middleware/flatServer/constants";
 import { GlobalStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { WECHAT } from "../../constants/process";
 import { RouteNameType } from "../../route-config";
+import { UserInfo } from "../../stores/GlobalStore";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { usePushHistory } from "../../utils/routes";
 import { joinRoomHandler } from "../utils/join-room-handler";
-import { useTranslation } from "react-i18next";
+import "./WeChatLogin.less";
 
 export const WeChatLogin = observer(function WeChatLogin() {
     const globalStore = useContext(GlobalStoreContext);

--- a/web/flat-web/src/pages/LoginPage/githubLogin.ts
+++ b/web/flat-web/src/pages/LoginPage/githubLogin.ts
@@ -1,9 +1,9 @@
-import { setAuthUUID, loginProcess } from "../../api-middleware/flatServer";
 import { v4 as uuidv4 } from "uuid";
-import { LoginExecutor } from "./utils";
-import { errorTips } from "../../components/Tips/ErrorTips";
+import { loginProcess, setAuthUUID } from "../../api-middleware/flatServer";
 import { FLAT_SERVER_LOGIN } from "../../api-middleware/flatServer/constants";
+import { errorTips } from "../../components/Tips/ErrorTips";
 import { GITHUB } from "../../constants/process";
+import { LoginExecutor } from "./utils";
 
 export const githubLogin: LoginExecutor = onSuccess => {
     let timer = NaN;

--- a/web/flat-web/src/pages/LoginPage/index.tsx
+++ b/web/flat-web/src/pages/LoginPage/index.tsx
@@ -1,16 +1,15 @@
-import "./style.less";
-
 import React, { useContext, useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
 import { LoginChannelType, LoginPanel } from "flat-components";
-import { LoginDisposer } from "./utils";
-import { githubLogin } from "./githubLogin";
-import { RouteNameType, usePushHistory } from "../../utils/routes";
-import { GlobalStoreContext } from "../../components/StoreProvider";
-import { WeChatLogin } from "./WeChatLogin";
-import { joinRoomHandler } from "../utils/join-room-handler";
-import { PRIVACY_URL, PRIVACY_URL_CN, SERVICE_URL, SERVICE_URL_CN } from "../../constants/process";
+import { observer } from "mobx-react-lite";
 import { useTranslation } from "react-i18next";
+import { GlobalStoreContext } from "../../components/StoreProvider";
+import { PRIVACY_URL, PRIVACY_URL_CN, SERVICE_URL, SERVICE_URL_CN } from "../../constants/process";
+import { RouteNameType, usePushHistory } from "../../utils/routes";
+import { joinRoomHandler } from "../utils/join-room-handler";
+import { githubLogin } from "./githubLogin";
+import { LoginDisposer } from "./utils";
+import { WeChatLogin } from "./WeChatLogin";
+import "./style.less";
 
 export const LoginPage = observer(function LoginPage() {
     const { i18n } = useTranslation();

--- a/web/flat-web/src/pages/ModifyOrdinaryRoomPage/OrdinaryRoomForm.tsx
+++ b/web/flat-web/src/pages/ModifyOrdinaryRoomPage/OrdinaryRoomForm.tsx
@@ -1,12 +1,12 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
+import { message } from "antd";
+import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory } from "react-router-dom";
-import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { ordinaryRoomInfo, updateOrdinaryRoom } from "../../api-middleware/flatServer";
 import EditRoomPage from "../../components/EditRoomPage";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 export interface OrdinaryRoomFormProps {
     roomUUID: string;
 }

--- a/web/flat-web/src/pages/ModifyOrdinaryRoomPage/PeriodicSubRoomForm.tsx
+++ b/web/flat-web/src/pages/ModifyOrdinaryRoomPage/PeriodicSubRoomForm.tsx
@@ -1,12 +1,12 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
+import { message } from "antd";
+import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory } from "react-router-dom";
-import { EditRoomFormInitialValues, EditRoomFormValues, LoadingPage } from "flat-components";
 import { periodicSubRoomInfo, updatePeriodicSubRoom } from "../../api-middleware/flatServer";
 import EditRoomPage from "../../components/EditRoomPage";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 
 /**
  * TODO: we forget set i18n in current file!!!

--- a/web/flat-web/src/pages/ModifyOrdinaryRoomPage/index.tsx
+++ b/web/flat-web/src/pages/ModifyOrdinaryRoomPage/index.tsx
@@ -1,5 +1,5 @@
-import { observer } from "mobx-react-lite";
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { useParams } from "react-router-dom";
 import { RouteNameType, RouteParams } from "../../utils/routes";
 import { OrdinaryRoomForm } from "./OrdinaryRoomForm";

--- a/web/flat-web/src/pages/ModifyPeriodicRoomPage/index.tsx
+++ b/web/flat-web/src/pages/ModifyPeriodicRoomPage/index.tsx
@@ -1,19 +1,19 @@
-import { message } from "antd";
 import React, { useEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
-import { useHistory, useParams } from "react-router-dom";
+import { message } from "antd";
 import {
     EditRoomFormInitialValues,
     EditRoomFormValues,
+    LoadingPage,
     getEndTimeFromRate,
     getRateFromEndTime,
-    LoadingPage,
 } from "flat-components";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import EditRoomPage from "../../components/EditRoomPage";
-import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
+import { observer } from "mobx-react-lite";
+import { useHistory, useParams } from "react-router-dom";
 import { periodicRoomInfo, updatePeriodicRoom } from "../../api-middleware/flatServer";
+import EditRoomPage from "../../components/EditRoomPage";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
+import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
 
 /**
  * TODO: we forget set i18n in current file!!!

--- a/web/flat-web/src/pages/OneToOnePage/OneToOneAvatar.tsx
+++ b/web/flat-web/src/pages/OneToOnePage/OneToOneAvatar.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { OneToOneVideoAvatar, OneToOneVideoAvatarProps } from "flat-components";
+import { RtcRoom } from "../../api-middleware/rtc/room";
 import { AvatarCanvas } from "../../components/AvatarCanvas";
 import { User } from "../../stores/user-store";
-import { RtcRoom } from "../../api-middleware/rtc/room";
 
 export interface OneToOneAvatarProps extends Omit<OneToOneVideoAvatarProps, "avatarUser"> {
     rtc: RtcRoom;

--- a/web/flat-web/src/pages/OneToOnePage/index.tsx
+++ b/web/flat-web/src/pages/OneToOnePage/index.tsx
@@ -1,44 +1,42 @@
-import "./OneToOnePage.less";
-
 import React, { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
-import { observer } from "mobx-react-lite";
 import { message } from "antd";
-import { RoomPhase } from "white-web-sdk";
 import {
+    CloudRecordBtn,
+    LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
-    LoadingPage,
-    Timer,
-    CloudRecordBtn,
 } from "flat-components";
-
-import InviteButton from "../../components/InviteButton";
-import { TopBarRightBtn } from "../../components/TopBarRightBtn";
-import { RealtimePanel } from "../../components/RealtimePanel";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { RoomPhase } from "white-web-sdk";
+import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
+import { RtcChannelType } from "../../api-middleware/rtc/room";
+import { AppStoreButton } from "../../components/AppStoreButton";
 import { ChatPanel } from "../../components/ChatPanel";
-import { OneToOneAvatar } from "./OneToOneAvatar";
+import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
+import { CloudStorageButton } from "../../components/CloudStorageButton";
 import {
     ExitRoomConfirm,
     ExitRoomConfirmType,
     useExitRoomConfirmModal,
 } from "../../components/ExitRoomConfirm";
+import InviteButton from "../../components/InviteButton";
+import { RealtimePanel } from "../../components/RealtimePanel";
+import { ShareScreen } from "../../components/ShareScreen";
+import { TopBarRightBtn } from "../../components/TopBarRightBtn";
 import { Whiteboard } from "../../components/Whiteboard";
-import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RecordingConfig, useClassRoomStore } from "../../stores/class-room-store";
-import { RtcChannelType } from "../../api-middleware/rtc/room";
+import { generateAvatar } from "../../utils/generate-avatar";
 import { useComputed } from "../../utils/mobx";
 import { RouteNameType, RouteParams } from "../../utils/routes";
-import { CloudStorageButton } from "../../components/CloudStorageButton";
-import { AgoraCloudRecordBackgroundConfigItem } from "../../api-middleware/flatServer/agora";
 import { runtime } from "../../utils/runtime";
-import { useTranslation } from "react-i18next";
-import { ShareScreen } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
+import { OneToOneAvatar } from "./OneToOneAvatar";
+import "./OneToOnePage.less";
 
 const recordingConfig: RecordingConfig = Object.freeze({
     channelType: RtcChannelType.Communication,

--- a/web/flat-web/src/pages/PeriodicRoomDetailPage/index.tsx
+++ b/web/flat-web/src/pages/PeriodicRoomDetailPage/index.tsx
@@ -1,17 +1,16 @@
-import "./style.less";
-
+import React, { useContext, useEffect, useState } from "react";
 import { message } from "antd";
+import { LoadingPage, PeriodicRoomPanel } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useHistory, useParams } from "react-router-dom";
-import React, { useContext, useEffect, useState } from "react";
 import { useLastLocation } from "react-router-last-location";
-import { LoadingPage, PeriodicRoomPanel } from "flat-components";
+import { cancelPeriodicRoom, cancelPeriodicSubRoom } from "../../api-middleware/flatServer";
 import { PageStoreContext, RoomStoreContext } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { globalStore } from "../../stores/GlobalStore";
 import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
-import { cancelPeriodicRoom, cancelPeriodicSubRoom } from "../../api-middleware/flatServer";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
+import "./style.less";
 
 /**
  * TODO: we forget set i18n in current file!!!

--- a/web/flat-web/src/pages/ReplayPage/index.tsx
+++ b/web/flat-web/src/pages/ReplayPage/index.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useRef, useState } from "react";
-import { RouteComponentProps, useParams, useHistory } from "react-router-dom";
-import { ErrorPage, LoadingPage } from "flat-components";
 import PlayerController from "@netless/player-controller";
-import { RealtimePanel } from "../../components/RealtimePanel";
-import { ChatPanelReplay } from "../../components/ChatPanelReplay";
+import { ErrorPage, LoadingPage } from "flat-components";
+import { observer } from "mobx-react-lite";
+import { RouteComponentProps, useHistory, useParams } from "react-router-dom";
 import { OrdinaryRoomInfo } from "../../api-middleware/flatServer";
 import { RoomType } from "../../api-middleware/flatServer/constants";
-import { observer } from "mobx-react-lite";
+import videoPlaySVG from "../../assets/image/video-play.svg";
+import { ChatPanelReplay } from "../../components/ChatPanelReplay";
+import { ExitReplayConfirmModal } from "../../components/Modal/ExitReplayConfirmModal";
+import { RealtimePanel } from "../../components/RealtimePanel";
+import { errorTips } from "../../components/Tips/ErrorTips";
 import { useClassRoomReplayStore } from "../../stores/class-room-replay-store";
 import { RouteNameType, RouteParams } from "../../utils/routes";
-
-import videoPlaySVG from "../../assets/image/video-play.svg";
 import "video.js/dist/video-js.min.css";
+// eslint-disable-next-line import/order
 import "./ReplayPage.less";
-import { ExitReplayConfirmModal } from "../../components/Modal/ExitReplayConfirmModal";
-import { errorTips } from "../../components/Tips/ErrorTips";
 
 export type ReplayPageProps = RouteComponentProps<{
     roomUUID: string;

--- a/web/flat-web/src/pages/ResourcePreviewPage/DynamicPreview.tsx
+++ b/web/flat-web/src/pages/ResourcePreviewPage/DynamicPreview.tsx
@@ -1,11 +1,10 @@
-import "./DynamicPreview.less";
-
 import React, { useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
+import { SlidePreviewer, previewSlide } from "@netless/app-slide";
 import { Region } from "flat-components";
-import { previewSlide, SlidePreviewer } from "@netless/app-slide";
+import { observer } from "mobx-react-lite";
 import { queryConvertingTaskStatus } from "../../api-middleware/courseware-converting";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
+import "./DynamicPreview.less";
 
 export interface DynamicPreviewProps {
     taskUUID: string;

--- a/web/flat-web/src/pages/ResourcePreviewPage/MediaPreview.tsx
+++ b/web/flat-web/src/pages/ResourcePreviewPage/MediaPreview.tsx
@@ -1,8 +1,7 @@
-import "./MediaPreview.less";
-
 import React from "react";
 import { observer } from "mobx-react-lite";
 import { getFileSuffix } from "./utils";
+import "./MediaPreview.less";
 
 export interface MediaPreviewProps {
     fileURL: string;

--- a/web/flat-web/src/pages/ResourcePreviewPage/StaticPreview.tsx
+++ b/web/flat-web/src/pages/ResourcePreviewPage/StaticPreview.tsx
@@ -1,22 +1,21 @@
-import "./StaticPreview.less";
-
-import { observer } from "mobx-react-lite";
-import { Region } from "flat-components";
 import React, { useEffect, useState } from "react";
+import { Region } from "flat-components";
+import { observer } from "mobx-react-lite";
 import { queryConvertingTaskStatus } from "../../api-middleware/courseware-converting";
 import { useSafePromise } from "../../utils/hooks/lifecycle";
+import "./StaticPreview.less";
 
 export interface StaticPreviewProps {
     taskUUID: string;
     taskToken: string;
     region: Region;
 }
-
 type ConvertedFileList =
     | Array<{
           width: number;
           height: number;
           conversionFileUrl: string;
+
           preview?: string | undefined;
       }>
     | undefined;

--- a/web/flat-web/src/pages/ResourcePreviewPage/index.tsx
+++ b/web/flat-web/src/pages/ResourcePreviewPage/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
+import { ErrorPage, Region } from "flat-components";
 import { observer } from "mobx-react-lite";
 import { useParams } from "react-router";
 import { RouteNameType, RouteParams } from "../../utils/routes";
 import { DynamicPreview } from "./DynamicPreview";
 import { MediaPreview } from "./MediaPreview";
 import { StaticPreview } from "./StaticPreview";
-import { ErrorPage, Region } from "flat-components";
 import { getFileSuffix } from "./utils";
 
 export interface ResourcePreviewPagePageProps {}

--- a/web/flat-web/src/pages/RoomDetailPage/index.tsx
+++ b/web/flat-web/src/pages/RoomDetailPage/index.tsx
@@ -1,22 +1,21 @@
 // import docsIconSVG from "../../assets/image/docs-icon.svg";
-import "./style.less";
-
 import React, { useContext, useEffect } from "react";
+import { message } from "antd";
 import { LoadingPage, RoomDetailPanel } from "flat-components";
 import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
 import { useHistory, useParams } from "react-router-dom";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import {
     GlobalStoreContext,
     PageStoreContext,
     RoomStoreContext,
 } from "../../components/StoreProvider";
 import { errorTips } from "../../components/Tips/ErrorTips";
+import { FLAT_WEB_BASE_URL } from "../../constants/process";
 import { RouteNameType, RouteParams, usePushHistory } from "../../utils/routes";
 import { joinRoomHandler } from "../utils/join-room-handler";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
-import { message } from "antd";
-import { FLAT_WEB_BASE_URL } from "../../constants/process";
-import { useTranslation } from "react-i18next";
+import "./style.less";
 
 export const RoomDetailPage = observer(function RoomDetailPage() {
     const { t } = useTranslation();

--- a/web/flat-web/src/pages/SmallClassPage/SmallClassAvatar.tsx
+++ b/web/flat-web/src/pages/SmallClassPage/SmallClassAvatar.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { SmallVideoAvatar, SmallVideoAvatarProps } from "flat-components";
-import { User } from "../../stores/user-store";
-import { AvatarCanvas } from "../../components/AvatarCanvas";
 import { RtcRoom } from "../../api-middleware/rtc/room";
+import { AvatarCanvas } from "../../components/AvatarCanvas";
+import { User } from "../../stores/user-store";
 
 interface SmallClassAvatarProps extends Omit<SmallVideoAvatarProps, "avatarUser"> {
     rtc: RtcRoom;

--- a/web/flat-web/src/pages/SmallClassPage/index.tsx
+++ b/web/flat-web/src/pages/SmallClassPage/index.tsx
@@ -1,50 +1,47 @@
 import React, { useEffect, useRef, useState } from "react";
 import { message } from "antd";
-import { RoomPhase } from "white-web-sdk";
-import { observer } from "mobx-react-lite";
-import { useParams } from "react-router-dom";
 import {
+    CloudRecordBtn,
+    LoadingPage,
     NetworkStatus,
     RoomInfo,
+    Timer,
     TopBar,
     TopBarDivider,
-    LoadingPage,
-    Timer,
-    CloudRecordBtn,
     TopBarRoundBtn,
 } from "flat-components";
-
-import InviteButton from "../../components/InviteButton";
-import { TopBarRightBtn } from "../../components/TopBarRightBtn";
-import { RealtimePanel } from "../../components/RealtimePanel";
-import { ChatPanel } from "../../components/ChatPanel";
-import { SmallClassAvatar } from "./SmallClassAvatar";
-import { Whiteboard } from "../../components/Whiteboard";
-import ExitRoomConfirm, {
-    ExitRoomConfirmType,
-    useExitRoomConfirmModal,
-} from "../../components/ExitRoomConfirm";
-import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
-
-import { ClassModeType } from "../../api-middleware/Rtm";
-import { RoomStatus } from "../../api-middleware/flatServer/constants";
+import { observer } from "mobx-react-lite";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { RoomPhase } from "white-web-sdk";
 import {
     AgoraCloudRecordBackgroundConfigItem,
     AgoraCloudRecordLayoutConfigItem,
 } from "../../api-middleware/flatServer/agora";
-import { RecordingConfig, useClassRoomStore, User } from "../../stores/class-room-store";
-import { RouteNameType, RouteParams } from "../../utils/routes";
-
-import "./SmallClassPage.less";
-import { CloudStorageButton } from "../../components/CloudStorageButton";
-import { runtime } from "../../utils/runtime";
+import { RoomStatus } from "../../api-middleware/flatServer/constants";
 import { RtcChannelType } from "../../api-middleware/rtc/room";
-import { useTranslation } from "react-i18next";
-import { ShareScreen } from "../../components/ShareScreen";
-import { generateAvatar } from "../../utils/generate-avatar";
-import { AppStoreButton } from "../../components/AppStoreButton";
+import { ClassModeType } from "../../api-middleware/Rtm";
 import classInteractionSVG from "../../assets/image/class-interaction.svg";
 import classLectureSVG from "../../assets/image/class-lecture.svg";
+import { AppStoreButton } from "../../components/AppStoreButton";
+import { ChatPanel } from "../../components/ChatPanel";
+import { RoomStatusStoppedModal } from "../../components/ClassRoom/RoomStatusStoppedModal";
+import { CloudStorageButton } from "../../components/CloudStorageButton";
+import ExitRoomConfirm, {
+    ExitRoomConfirmType,
+    useExitRoomConfirmModal,
+} from "../../components/ExitRoomConfirm";
+import InviteButton from "../../components/InviteButton";
+import { RealtimePanel } from "../../components/RealtimePanel";
+import { ShareScreen } from "../../components/ShareScreen";
+import { TopBarRightBtn } from "../../components/TopBarRightBtn";
+import { Whiteboard } from "../../components/Whiteboard";
+import { RecordingConfig, User, useClassRoomStore } from "../../stores/class-room-store";
+import { generateAvatar } from "../../utils/generate-avatar";
+import { RouteNameType, RouteParams } from "../../utils/routes";
+import { runtime } from "../../utils/runtime";
+import { SmallClassAvatar } from "./SmallClassAvatar";
+import "./SmallClassPage.less";
 
 const CLASSROOM_WIDTH = 1200;
 const AVATAR_AREA_WIDTH = CLASSROOM_WIDTH - 16 * 2;

--- a/web/flat-web/src/pages/UserScheduledPage/index.tsx
+++ b/web/flat-web/src/pages/UserScheduledPage/index.tsx
@@ -1,18 +1,18 @@
 import React, { useContext, useState } from "react";
+import { addMinutes, addWeeks, getDay, isBefore, roundToNearestMinutes } from "date-fns";
+import { EditRoomFormValues } from "flat-components";
 import { observer } from "mobx-react-lite";
-import { isBefore, addMinutes, roundToNearestMinutes, getDay, addWeeks } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import { RoomType } from "../../api-middleware/flatServer/constants";
+import EditRoomPage from "../../components/EditRoomPage";
 import {
     ConfigStoreContext,
     GlobalStoreContext,
     RoomStoreContext,
 } from "../../components/StoreProvider";
-import { useSafePromise } from "../../utils/hooks/lifecycle";
-import EditRoomPage from "../../components/EditRoomPage";
-import { useHistory } from "react-router-dom";
 import { errorTips } from "../../components/Tips/ErrorTips";
-import { EditRoomFormValues } from "flat-components";
-import { useTranslation } from "react-i18next";
+import { useSafePromise } from "../../utils/hooks/lifecycle";
 
 const getInitialBeginTime = (): Date => {
     const now = new Date();

--- a/web/flat-web/src/pages/UserSettingPage/GeneralSettingPage/index.tsx
+++ b/web/flat-web/src/pages/UserSettingPage/GeneralSettingPage/index.tsx
@@ -1,11 +1,10 @@
-import "./index.less";
-
-import { Checkbox, Radio } from "antd";
 import React, { useContext } from "react";
-import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import { Checkbox, Radio } from "antd";
+import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { useTranslation } from "react-i18next";
-import type { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { GlobalStoreContext } from "../../../components/StoreProvider";
+import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import "./index.less";
 
 enum SelectLanguage {
     Chinese,

--- a/web/flat-web/src/pages/UserSettingPage/HotKeySettingPage/index.tsx
+++ b/web/flat-web/src/pages/UserSettingPage/HotKeySettingPage/index.tsx
@@ -1,9 +1,8 @@
-import "./index.less";
-
-import { Table } from "antd";
 import React from "react";
-import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import { Table } from "antd";
 import { useTranslation } from "react-i18next";
+import { UserSettingLayoutContainer } from "../UserSettingLayoutContainer";
+import "./index.less";
 
 interface HotKeyTable {
     name: string;

--- a/web/flat-web/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
+++ b/web/flat-web/src/pages/UserSettingPage/UserSettingLayoutContainer.tsx
@@ -1,13 +1,12 @@
 /* eslint react/display-name: off */
-import generalSVG from "./icons/general.svg";
+import React, { useContext, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { PageStoreContext } from "../../components/StoreProvider";
+import { RouteNameType, routeConfig } from "../../route-config";
 import aboutSVG from "./icons/about.svg";
+import generalSVG from "./icons/general.svg";
 import hotkeySVG from "./icons/hotkey.svg";
 import "./UserSettingLayoutContainer.less";
-
-import React, { useContext, useEffect } from "react";
-import { routeConfig, RouteNameType } from "../../route-config";
-import { PageStoreContext } from "../../components/StoreProvider";
-import { useTranslation } from "react-i18next";
 
 export const UserSettingLayoutContainer: React.FC = ({ children }): React.ReactElement => {
     const { t } = useTranslation();

--- a/web/flat-web/src/pages/utils/join-room-handler.ts
+++ b/web/flat-web/src/pages/utils/join-room-handler.ts
@@ -1,8 +1,8 @@
-import { generateRoutePath, RouteNameType, usePushHistory } from "../../utils/routes";
-import { roomStore } from "../../stores/room-store";
 import { RoomType } from "../../api-middleware/flatServer/constants";
 import { errorTips } from "../../components/Tips/ErrorTips";
 import { globalStore } from "../../stores/GlobalStore";
+import { roomStore } from "../../stores/room-store";
+import { RouteNameType, generateRoutePath, usePushHistory } from "../../utils/routes";
 
 export const joinRoomHandler = async (
     roomUUID: string,

--- a/web/flat-web/src/stores/GlobalStore.ts
+++ b/web/flat-web/src/stores/GlobalStore.ts
@@ -1,7 +1,7 @@
+import { UID } from "agora-rtc-sdk-ng";
 import { Region } from "flat-components";
-import { autoPersistStore } from "./utils";
 import { LoginProcessResult } from "../api-middleware/flatServer";
-import type { UID } from "agora-rtc-sdk-ng";
+import { autoPersistStore } from "./utils";
 
 // clear storage if not match
 const LS_VERSION = 1;

--- a/web/flat-web/src/stores/class-room-replay-store.ts
+++ b/web/flat-web/src/stores/class-room-replay-store.ts
@@ -1,15 +1,15 @@
 import { useState } from "react";
-import { makeAutoObservable, observable, runInAction } from "mobx";
 import dateAdd from "date-fns/add";
+import { makeAutoObservable, observable, runInAction } from "mobx";
+import { RoomType } from "../api-middleware/flatServer/constants";
 import { Rtm as RTMAPI, RTMessageType } from "../api-middleware/Rtm";
 import { SmartPlayer, SmartPlayerEventType } from "../api-middleware/SmartPlayer";
-import { globalStore } from "./GlobalStore";
-import { RoomItem, roomStore } from "./room-store";
 import { NODE_ENV } from "../constants/process";
 import { useAutoRun } from "../utils/mobx";
-import { RoomType } from "../api-middleware/flatServer/constants";
-import { UserStore } from "./user-store";
 import { RTMChannelMessage } from "./class-room-store";
+import { globalStore } from "./GlobalStore";
+import { RoomItem, roomStore } from "./room-store";
+import { UserStore } from "./user-store";
 
 export class ClassRoomReplayStore {
     public readonly roomUUID: string;

--- a/web/flat-web/src/stores/class-room-store.ts
+++ b/web/flat-web/src/stores/class-room-store.ts
@@ -1,10 +1,9 @@
+import { useEffect, useState } from "react";
 import { NetworkQuality } from "agora-rtc-sdk-ng";
 import { message } from "antd";
 import dateSub from "date-fns/sub";
-import type { i18n } from "i18next";
+import { i18n } from "i18next";
 import { action, autorun, makeAutoObservable, observable, reaction, runInAction } from "mobx";
-import { useEffect, useState } from "react";
-import { i18n as i18next } from "../utils/i18n";
 import { v4 as uuidv4 } from "uuid";
 import { CloudRecording } from "../api-middleware/CloudRecording";
 import {
@@ -19,18 +18,19 @@ import {
     CloudRecordUpdateLayoutPayload,
 } from "../api-middleware/flatServer/agora";
 import { RoomStatus, RoomType } from "../api-middleware/flatServer/constants";
-import { RtcChannelType, RtcRoom as RTCAPI } from "../api-middleware/rtc/room";
+import { RtcRoom as RTCAPI, RtcChannelType } from "../api-middleware/rtc/room";
 import {
     ClassModeType,
     NonDefaultUserProp,
     Rtm as RTMAPI,
+    RTMEvents,
     RTMessage,
     RTMessageType,
-    RTMEvents,
 } from "../api-middleware/Rtm";
 import { errorTips } from "../components/Tips/ErrorTips";
 import { NODE_ENV } from "../constants/process";
 import { useSafePromise } from "../utils/hooks/lifecycle";
+import { i18n as i18next } from "../utils/i18n";
 import { useAutoRun } from "../utils/mobx";
 import { RouteNameType, usePushHistory } from "../utils/routes";
 import { globalStore } from "./GlobalStore";

--- a/web/flat-web/src/stores/room-store.ts
+++ b/web/flat-web/src/stores/room-store.ts
@@ -1,28 +1,28 @@
 /* eslint no-redeclare: off */
-import { makeAutoObservable, observable, runInAction } from "mobx";
 import { Region } from "flat-components";
+import { makeAutoObservable, observable, runInAction } from "mobx";
 import {
-    cancelRoom,
     CancelRoomPayload,
-    createOrdinaryRoom,
     CreateOrdinaryRoomPayload,
-    createPeriodicRoom,
     CreatePeriodicRoomPayload,
-    joinRoom,
     JoinRoomResult,
-    listRooms,
     ListRoomsPayload,
     ListRoomsType,
+    PeriodicRoomInfoResult,
+    PeriodicSubRoomInfoPayload,
+    cancelRoom,
+    createOrdinaryRoom,
+    createPeriodicRoom,
+    joinRoom,
+    listRooms,
     ordinaryRoomInfo,
     periodicRoomInfo,
-    PeriodicRoomInfoResult,
     periodicSubRoomInfo,
-    PeriodicSubRoomInfoPayload,
     recordInfo,
 } from "../api-middleware/flatServer";
 import { RoomStatus, RoomType } from "../api-middleware/flatServer/constants";
-import { globalStore } from "./GlobalStore";
 import { configStore } from "./config-store";
+import { globalStore } from "./GlobalStore";
 
 // Sometime we may only have pieces of the room info
 /** Ordinary room + periodic sub-room */

--- a/web/flat-web/src/stores/share-screen-store/index.ts
+++ b/web/flat-web/src/stores/share-screen-store/index.ts
@@ -1,6 +1,6 @@
+import { IAgoraRTCClient } from "agora-rtc-sdk-ng";
 import { autorun, makeAutoObservable, observable, reaction } from "mobx";
 import { RTCShareScreen } from "../../api-middleware/rtc/share-screen";
-import { IAgoraRTCClient } from "agora-rtc-sdk-ng";
 import { ListenerOtherUserShareScreen } from "./listener-other-user-share-screen";
 
 export class ShareScreenStore {

--- a/web/flat-web/src/stores/user-store.ts
+++ b/web/flat-web/src/stores/user-store.ts
@@ -1,6 +1,6 @@
 import { action, makeAutoObservable, observable } from "mobx";
-import { CloudRecordStartPayload } from "../api-middleware/flatServer/agora";
 import { usersInfo } from "../api-middleware/flatServer";
+import { CloudRecordStartPayload } from "../api-middleware/flatServer/agora";
 import { configStore } from "./config-store";
 
 export interface User {

--- a/web/flat-web/src/stores/whiteboard-store.ts
+++ b/web/flat-web/src/stores/whiteboard-store.ts
@@ -1,9 +1,7 @@
-import "video.js/dist/video-js.css";
-
-import type { Attributes as SlideAttributes } from "@netless/app-slide";
+import { Attributes as SlideAttributes } from "@netless/app-slide";
 import { AddAppParams, BuiltinApps, WindowManager } from "@netless/window-manager";
 import { message } from "antd";
-import type { i18n } from "i18next";
+import { i18n } from "i18next";
 import { debounce } from "lodash-es";
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { isMobile, isWindows } from "react-device-detect";
@@ -28,6 +26,7 @@ import { coursewarePreloader } from "../utils/courseware-preloader";
 import { ServerRequestError } from "../utils/error/server-request-error";
 import { getFileExt, isPPTX } from "../utils/file";
 import { globalStore } from "./GlobalStore";
+import "video.js/dist/video-js.css";
 
 export class WhiteboardStore {
     public room: Room | null = null;

--- a/web/flat-web/src/tasks/index.ts
+++ b/web/flat-web/src/tasks/index.ts
@@ -1,6 +1,6 @@
 import { initRegisterApps } from "./init-register-apps";
 import { initServiceWork } from "./init-service-works";
-import { initWhiteSDK } from "./init-white-sdk";
 import { initUI } from "./init-ui";
+import { initWhiteSDK } from "./init-white-sdk";
 
 export const tasks = [initServiceWork, initWhiteSDK, initUI, initRegisterApps];

--- a/web/flat-web/src/tasks/init-register-apps.ts
+++ b/web/flat-web/src/tasks/init-register-apps.ts
@@ -1,5 +1,5 @@
-import { WindowManager } from "@netless/window-manager";
 import { addHooks as addHooksSlide } from "@netless/app-slide";
+import { WindowManager } from "@netless/window-manager";
 
 const registerApps = (): void => {
     void WindowManager.register({

--- a/web/flat-web/src/tasks/init-ui.tsx
+++ b/web/flat-web/src/tasks/init-ui.tsx
@@ -1,22 +1,17 @@
-import "flat-components/theme/index.less";
-
-import "../theme.less";
-
 import React, { useEffect, useMemo } from "react";
-import ReactDOM from "react-dom";
-import { useUpdate } from "react-use";
-
 import { ConfigProvider } from "antd";
-import zhCN from "antd/lib/locale/zh_CN";
 import enUS from "antd/lib/locale/en_US";
-
+import zhCN from "antd/lib/locale/zh_CN";
+import { configure } from "mobx";
+import ReactDOM from "react-dom";
 import { I18nextProvider } from "react-i18next";
-import { i18n } from "../utils/i18n";
+import { useUpdate } from "react-use";
 import { AppRoutes } from "../AppRoutes";
 import { StoreProvider } from "../components/StoreProvider";
+import { i18n } from "../utils/i18n";
+import "../theme.less";
+import "flat-components/theme/index.less";
 
-/** configure right after import */
-import { configure } from "mobx";
 configure({
     isolateGlobalState: true,
 });

--- a/web/flat-web/src/tasks/init-white-sdk.ts
+++ b/web/flat-web/src/tasks/init-white-sdk.ts
@@ -1,4 +1,4 @@
-import { injectCustomStyle, CursorNames } from "white-web-sdk";
+import { CursorNames, injectCustomStyle } from "white-web-sdk";
 
 // https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
 // https://yoksel.github.io/url-encoder

--- a/web/flat-web/src/utils/drag-and-drop/image.ts
+++ b/web/flat-web/src/utils/drag-and-drop/image.ts
@@ -1,6 +1,6 @@
 import { message } from "antd";
 import { v4 as v4uuid } from "uuid";
-import type { Room, Size } from "white-web-sdk";
+import { Room, Size } from "white-web-sdk";
 import { listFiles } from "../../api-middleware/flatServer/storage";
 import { i18n } from "../i18n";
 import { UploadTask } from "../upload-task-manager/upload-task";

--- a/web/flat-web/src/utils/error/server-request-error.ts
+++ b/web/flat-web/src/utils/error/server-request-error.ts
@@ -1,5 +1,5 @@
-import { RequestError } from "./request-error";
 import { RequestErrorCode, RequestErrorMessage } from "../../constants/error-code";
+import { RequestError } from "./request-error";
 
 export class ServerRequestError extends RequestError {
     public errorCode: RequestErrorCode;

--- a/web/flat-web/src/utils/i18n.ts
+++ b/web/flat-web/src/utils/i18n.ts
@@ -1,8 +1,8 @@
+import en from "flat-i18n/en.json";
+import zhCN from "flat-i18n/zh-CN.json";
 import i18next, { Resource } from "i18next";
 import I18nextBrowserLanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
-import en from "flat-i18n/en.json";
-import zhCN from "flat-i18n/zh-CN.json";
 
 const messages: Resource = {
     en: { translation: en },

--- a/web/flat-web/src/utils/mobx.ts
+++ b/web/flat-web/src/utils/mobx.ts
@@ -1,18 +1,18 @@
+import { DependencyList, useEffect, useMemo, useRef } from "react";
 import {
-    autorun,
     IAutorunOptions,
+    IComputedValue,
+    IComputedValueOptions,
     IReactionOptions,
     IReactionPublic,
     IWhenOptions,
+    autorun,
+    computed,
+    observable,
     reaction,
     when,
-    computed,
-    IComputedValueOptions,
-    IComputedValue,
-    observable,
 } from "mobx";
 import { useLocalObservable } from "mobx-react-lite";
-import { useEffect, DependencyList, useMemo, useRef } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 
 /**

--- a/web/flat-web/src/utils/routes.ts
+++ b/web/flat-web/src/utils/routes.ts
@@ -1,6 +1,6 @@
-import { routeConfig, RouteConfig, RouteNameType, ExtraRouteConfig } from "../route-config";
-import { generatePath, useHistory } from "react-router-dom";
 import { useCallback } from "react";
+import { generatePath, useHistory } from "react-router-dom";
+import { ExtraRouteConfig, RouteConfig, RouteNameType, routeConfig } from "../route-config";
 
 export { RouteNameType } from "../route-config";
 

--- a/web/flat-web/src/utils/upload-task-manager/index.ts
+++ b/web/flat-web/src/utils/upload-task-manager/index.ts
@@ -1,7 +1,7 @@
+import { UploadID } from "flat-components";
 import { makeAutoObservable, observable, runInAction } from "mobx";
 import { cancelUpload } from "../../api-middleware/flatServer/storage";
 import { UploadStatusType, UploadTask } from "./upload-task";
-import { UploadID } from "flat-components";
 
 export enum UploadTaskManagerStatusType {
     Idle = 1,

--- a/web/flat-web/src/utils/upload-task-manager/upload-task.ts
+++ b/web/flat-web/src/utils/upload-task-manager/upload-task.ts
@@ -1,16 +1,16 @@
+import Axios, { CancelTokenSource } from "axios";
 import { makeAutoObservable, observable } from "mobx";
 import { v4 as v4uuid } from "uuid";
-import Axios, { CancelTokenSource } from "axios";
 import {
+    UploadStartResult,
     cancelUpload,
     uploadFinish,
     uploadStart,
-    UploadStartResult,
 } from "../../api-middleware/flatServer/storage";
-import { CLOUD_STORAGE_OSS_ALIBABA_CONFIG } from "../../constants/process";
-import { ServerRequestError } from "../error/server-request-error";
-import { configStore } from "../../stores/config-store";
 import { RequestErrorCode } from "../../constants/error-code";
+import { CLOUD_STORAGE_OSS_ALIBABA_CONFIG } from "../../constants/process";
+import { configStore } from "../../stores/config-store";
+import { ServerRequestError } from "../error/server-request-error";
 
 export enum UploadStatusType {
     Pending = 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,6 +3155,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/loadable__component@^5.13.3":
   version "5.13.4"
   resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.13.4.tgz#a4646b2406b1283efac1a9d9485824a905b33d4a"
@@ -4464,6 +4469,17 @@ array-includes@^3.0.3, array-includes@^3.1.1, array-includes@^3.1.2, array-inclu
     get-intrinsic "^1.1.1"
     is-string "^1.0.5"
 
+array-includes@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
+  integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 array-initial@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/array-initial/-/array-initial-1.1.0.tgz#2fa74b26739371c3947bd7a7adc73be334b3d795"
@@ -4524,6 +4540,15 @@ array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.4:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
+
+array.prototype.flat@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
+  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
 
 array.prototype.flatmap@^1.2.1, array.prototype.flatmap@^1.2.4:
   version "1.2.4"
@@ -7289,6 +7314,32 @@ es-abstract@^1.17.0-next.0, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.19.0, es-abstract@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
@@ -7461,7 +7512,7 @@ eslint-config-react-app@^6.0.0:
   dependencies:
     confusing-browser-globals "^1.0.10"
 
-eslint-import-resolver-node@^0.3.5:
+eslint-import-resolver-node@^0.3.5, eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
   integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
@@ -7487,6 +7538,14 @@ eslint-module-utils@^2.6.2:
   dependencies:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
+
+eslint-module-utils@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.2.tgz#1d0aa455dcf41052339b63cada8ab5fd57577129"
+  integrity sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==
+  dependencies:
+    debug "^3.2.7"
+    find-up "^2.1.0"
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -7523,6 +7582,25 @@ eslint-plugin-import@2.x:
     read-pkg-up "^3.0.0"
     resolve "^1.20.0"
     tsconfig-paths "^3.9.0"
+
+eslint-plugin-import@^2.25.4:
+  version "2.25.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
+  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.2"
+    has "^1.0.3"
+    is-core-module "^2.8.0"
+    is-glob "^4.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.5"
+    resolve "^1.20.0"
+    tsconfig-paths "^3.12.0"
 
 eslint-plugin-jsx-a11y@6.x, eslint-plugin-jsx-a11y@^6.4.1:
   version "6.4.1"
@@ -8600,6 +8678,14 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
+
 get-uri@3:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
@@ -9662,7 +9748,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-callable@^1.1.4, is-callable@^1.2.3:
+is-callable@^1.1.4, is-callable@^1.2.3, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
@@ -9827,6 +9913,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
@@ -9939,7 +10032,7 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.1.2, is-regex@^1.1.3:
+is-regex@^1.1.2, is-regex@^1.1.3, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -9967,6 +10060,11 @@ is-set@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
   integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -9977,7 +10075,7 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
-is-string@^1.0.5, is-string@^1.0.6:
+is-string@^1.0.5, is-string@^1.0.6, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
   integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
@@ -10016,6 +10114,13 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-weakref@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-what@^3.12.0:
   version "3.14.1"
@@ -11962,6 +12067,15 @@ object.values@^1.1.0, object.values@^1.1.3, object.values@^1.1.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+object.values@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.5.tgz#959f63e3ce9ef108720333082131e4a459b716ac"
+  integrity sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 objectorarray@^1.0.5:
   version "1.0.5"
@@ -15914,6 +16028,16 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tsconfig-paths@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
+  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tsconfig-paths@^3.9.0:
   version "3.10.1"


### PR DESCRIPTION
### Changes

- Add [`sort-imports`](https://eslint.org/docs/rules/sort-imports)
- Add [`import/order`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md)
- Add [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md)
- Add [`@typescript-eslint/consistent-type-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md)

I moved all unassigned imports (CSS/Less/MP3) to the bottom for a better visual.

### When to disable it?

And I am using `eslint-disable-next-line import/order` to allow our unassigned sibling CSS/Less imports after those imports from package. Just to avoid some style override issues. Here is an example:

```js
import 'videojs/example.css';
// eslint-disable-next-line import/order
import './style.less';
```

I don't want to [take too much effort](https://github.com/import-js/eslint-plugin-import/issues/1239#issuecomment-716683648) on [pathGroups](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#pathgroups-array-of-objects). Using `eslint-disable-next-line import/order` is easilier.

### Tips

Use the split diff view for better visual.

<img width="189" alt="image" src="https://user-images.githubusercontent.com/8186898/150193185-0ac295a7-86d5-4cc6-abd6-113afc567a27.png">

### Plan

I'm going to enable ESLint for all workspaces and root files in another PR.