### PR TITLE
refactor(project): upgrade white-web-sdk to 2.16.1

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -14,10 +14,10 @@
     "@netless/cursor-tool": "^0.1.0",
     "@netless/fetch-middleware": "^1.0.7",
     "@netless/player-controller": "^0.0.9",
-    "@netless/redo-undo": "^0.0.5",
+    "@netless/redo-undo": "^0.1.9",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.4.0-canary.5",
+    "@netless/window-manager": "0.4.0-canary.18",
     "@videojs/vhs-utils": "^2.3.0",
     "agora-rtm-sdk": "^1.4.3",
     "antd": "^4.15.4",
@@ -46,7 +46,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.14"
+    "white-web-sdk": "2.16.1"
   },
   "devDependencies": {
     "@netless/eslint-plugin": "1.1.2",

--- a/desktop/renderer-app/src/components/Whiteboard.tsx
+++ b/desktop/renderer-app/src/components/Whiteboard.tsx
@@ -46,7 +46,7 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
     useEffect(() => {
         const mountWindowManager = async (): Promise<void> => {
             if (whiteboardEl && collectorEl && room) {
-                await WindowManager.mount({
+                const windowManager = await WindowManager.mount({
                     room,
                     container: whiteboardEl,
                     collectorContainer: collectorEl,
@@ -61,7 +61,9 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                     chessboard: false,
                 });
 
-                whiteboardStore.onMainViewModeChange();
+                whiteboardStore.updateWindowManager(windowManager);
+                whiteboardStore.onMainViewSceneChange();
+                whiteboardStore.onMainViewRedoUndoStepsChange();
                 whiteboardStore.onWindowManagerBoxStateChange(
                     whiteboardStore.windowManager?.boxState,
                 );
@@ -224,7 +226,11 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                             "is-disabled": whiteboardStore.isWindowMaximization,
                         })}
                     >
-                        <RedoUndo room={room} />
+                        <RedoUndo
+                            redoSteps={whiteboardStore.redoSteps}
+                            room={room}
+                            undoSteps={whiteboardStore.undoSteps}
+                        />
                     </div>
                     <div
                         className={classNames("page-controller-box", {
@@ -234,7 +240,7 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                         <ScenesController
                             addScene={whiteboardStore.addMainViewScene}
                             currentSceneIndex={whiteboardStore.currentSceneIndex}
-                            disabled={whiteboardStore.isFocusWindow}
+                            disabled={false}
                             nextScene={whiteboardStore.nextMainViewScene}
                             preScene={whiteboardStore.preMainViewScene}
                             scenesCount={whiteboardStore.scenesCount}

--- a/packages/flat-components/src/components/ClassroomPage/ScenesController/style.less
+++ b/packages/flat-components/src/components/ClassroomPage/ScenesController/style.less
@@ -30,8 +30,8 @@
 }
 
 .scenes-controller-info {
-    margin-left: 8px;
-    margin-right: 8px;
+    min-width: 42px;
+    text-align: center;
     font-size: 12px;
     color: #212324;
 }

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -47,10 +47,10 @@
     "@netless/combine-player": "^1.1.6",
     "@netless/cursor-tool": "^0.1.0",
     "@netless/player-controller": "^0.0.9",
-    "@netless/redo-undo": "^0.0.5",
+    "@netless/redo-undo": "^0.1.9",
     "@netless/tool-box": "^0.1.6",
     "@netless/video-js-plugin": "^0.3.6",
-    "@netless/window-manager": "^0.4.0-canary.5",
+    "@netless/window-manager": "0.4.0-canary.18",
     "@videojs/vhs-utils": "^2.3.0",
     "@zip.js/zip.js": "^2.3.7",
     "agora-rtc-sdk-ng": "^4.5.0",
@@ -81,7 +81,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.15.14"
+    "white-web-sdk": "2.16.1"
   },
   "scripts": {
     "postinstall": "esbuild-dev ./scripts/post-install.ts",

--- a/web/flat-web/src/components/Whiteboard.tsx
+++ b/web/flat-web/src/components/Whiteboard.tsx
@@ -46,7 +46,7 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
     useEffect(() => {
         const mountWindowManager = async (): Promise<void> => {
             if (whiteboardEl && collectorEl && room) {
-                await WindowManager.mount({
+                const windowManager = await WindowManager.mount({
                     room,
                     container: whiteboardEl,
                     cursor: true,
@@ -61,7 +61,9 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                     chessboard: false,
                 });
 
-                whiteboardStore.onMainViewModeChange();
+                whiteboardStore.updateWindowManager(windowManager);
+                whiteboardStore.onMainViewSceneChange();
+                whiteboardStore.onMainViewRedoUndoStepsChange();
                 whiteboardStore.onWindowManagerBoxStateChange(
                     whiteboardStore.windowManager?.boxState,
                 );
@@ -225,7 +227,11 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                             "is-disabled": whiteboardStore.isWindowMaximization,
                         })}
                     >
-                        <RedoUndo room={room} />
+                        <RedoUndo
+                            redoSteps={whiteboardStore.redoSteps}
+                            room={room}
+                            undoSteps={whiteboardStore.undoSteps}
+                        />
                     </div>
                     <div
                         className={classNames("page-controller-box", {
@@ -235,7 +241,7 @@ export const Whiteboard = observer<WhiteboardProps>(function Whiteboard({
                         <ScenesController
                             addScene={whiteboardStore.addMainViewScene}
                             currentSceneIndex={whiteboardStore.currentSceneIndex}
-                            disabled={whiteboardStore.isFocusWindow}
+                            disabled={false}
                             nextScene={whiteboardStore.nextMainViewScene}
                             preScene={whiteboardStore.preMainViewScene}
                             scenesCount={whiteboardStore.scenesCount}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,14 +1867,6 @@
   resolved "https://registry.npmjs.org/@netless/app-countdown/-/app-countdown-0.0.1.tgz#97772577008ead43c10812600a121e89fc18c8e3"
   integrity sha512-pOJLEQEHoSujAN+Q0kB257XKo3D6+J5Lz7s57OMc0/clhgaciOidBvNoTpsN70mOGRGpGiWpMovaoSYTihuU4Q==
 
-"@netless/app-docs-viewer@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/@netless/app-docs-viewer/-/app-docs-viewer-0.2.0.tgz#86d0241656f3716109a3659e9cfb4405c5d7964e"
-  integrity sha512-FjoPETCbznPtwm1ESAhAwtjm2bUyC9ccAdbpw6ZmNjbivLumLoQy+kRbzEUzOyOfZwwuu3qcwjw1NlrNyMYfug==
-  dependencies:
-    debounce-fn "^5.0.0"
-    vanilla-lazyload "^17.5.0"
-
 "@netless/app-geogebra@^0.0.2":
   version "0.0.2"
   resolved "https://registry.npmjs.org/@netless/app-geogebra/-/app-geogebra-0.0.2.tgz#0c462ab81d25817dd243632c85a99482c0cef34a"
@@ -1884,11 +1876,6 @@
   version "0.0.2"
   resolved "https://registry.npmjs.org/@netless/app-iframe-bridge/-/app-iframe-bridge-0.0.2.tgz#308ea74220b83abf077395d6c819778ffa63b4ad"
   integrity sha512-G7wZoX0CjqVBGeP0eYp8e7OYxRIN+vNwZJPxO45Gv4e8Nb/i3hF82F8FALaiLgWC89HG74XGNa98DJ3R+wSz2g==
-
-"@netless/app-media-player@0.1.0-beta.5":
-  version "0.1.0-beta.5"
-  resolved "https://registry.npmjs.org/@netless/app-media-player/-/app-media-player-0.1.0-beta.5.tgz#13ad8680be81503f5dc48c4c4e9848ba15b76e5a"
-  integrity sha512-q24tZnDGwTM8fvSs97qavuF8w8cXa4Tx3Nl7Xvig5Um4XKrfNijjLK9pI1cdctfuefl9s8wrG8JNCN2C6yqeDw==
 
 "@netless/app-monaco@^0.1.12":
   version "0.1.12"
@@ -1944,22 +1931,10 @@
     "@ant-design/icons" "^4.5.0"
     "@netless/combine-player" "^1.1.3"
 
-"@netless/redo-undo@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@netless/redo-undo/-/redo-undo-0.0.5.tgz#c5b00f5940ef33a0d6a810cd0935f4d9c172ea52"
-  integrity sha512-P8ceK3hSY2eMfFIjBeSpRsqXpjjTea9bBWyRF8t8q0kLR4ICld2VMFMRbytqZ8sjCFy9CgbicuBOdMj7juABIQ==
-
-"@netless/telebox-insider@0.2.17":
-  version "0.2.17"
-  resolved "https://registry.npmjs.org/@netless/telebox-insider/-/telebox-insider-0.2.17.tgz#c351f48fc03c265f1cffe0bad0761011f13aad48"
-  integrity sha512-+nTLm/LM4NNso4epdLhtTfuYDx+J8iMwX41vSUlN6pEjMOCl4HFv8paEjeYT8WYywT4gd+vHG1n7vsx6KMRJZw==
-  dependencies:
-    "@types/shallowequal" "^1.1.1"
-    eventemitter3 "^4.0.7"
-    shallowequal "^1.1.0"
-    side-effect-manager "^0.1.5"
-    stylefire "^7.0.3"
-    value-enhancer "^0.0.8"
+"@netless/redo-undo@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.npmjs.org/@netless/redo-undo/-/redo-undo-0.1.9.tgz#b91cec339089581e514f3f27e4959605e5fa8f98"
+  integrity sha512-o8pWeysEYzTuchsFNtjU2HALXgiHOP6qHlEf2JXUwxSJGhOY6zcPAs5OILr8RTxlOrgn8cRTcAU0PwcZd2uB9A==
 
 "@netless/tool-box@^0.1.6":
   version "0.1.6"
@@ -1971,15 +1946,12 @@
   resolved "https://registry.yarnpkg.com/@netless/video-js-plugin/-/video-js-plugin-0.3.7.tgz#6c1f174f20e8a93634e1770e7e535c1302bdf22b"
   integrity sha512-UG1t9464w1bZT9kzdhxj/K7R6jqI9sqYfqfUQJ2w9JRWsNibL6O16OC81iwBJT6nkGXEVN7z2pqHvNg1OhKppw==
 
-"@netless/window-manager@^0.4.0-canary.5":
-  version "0.4.0-canary.5"
-  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.4.0-canary.5.tgz#d812bdea4687404a9921ffb27d60f36f08ee869e"
-  integrity sha512-R7669KKeG9G/52FB+Jjj3a1CV+WxGDNYOINs4xW1QJu7iUd1yfpqUJ35VNJQlHpJoEnFDJV0j6l8NQMMCU/pAQ==
+"@netless/window-manager@0.4.0-canary.18":
+  version "0.4.0-canary.18"
+  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-0.4.0-canary.18.tgz#f518a6c63f41f0470b57d331fbe156b1c0978d88"
+  integrity sha512-K9aYuXgLk1PQ4xV4XxrGNkTYH17IobGyIZPS7tWl5/lI3skZNqe+jrcdeQVON9MHmdVNDCMLMyUy93Ri5f6YmQ==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
-    "@netless/app-docs-viewer" "0.2.0"
-    "@netless/app-media-player" "0.1.0-beta.5"
-    "@netless/telebox-insider" "0.2.17"
     emittery "^0.9.2"
     lodash "^4.17.21"
     p-retry "^4.6.1"
@@ -2037,22 +2009,6 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
     source-map "^0.7.3"
-
-"@popmotion/easing@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
-  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
-
-"@popmotion/popcorn@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz#a5f906fccdff84526e3fcb892712d7d8a98d6adc"
-  integrity sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
-  dependencies:
-    "@popmotion/easing" "^1.0.1"
-    framesync "^4.0.1"
-    hey-listen "^1.0.8"
-    style-value-types "^3.1.7"
-    tslib "^1.10.0"
 
 "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.9.3"
@@ -3433,11 +3389,6 @@
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
   integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
-
-"@types/shallowequal@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz#aad262bb3f2b1257d94c71d545268d592575c9b1"
-  integrity sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -6522,13 +6473,6 @@ dayjs@1.x:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
   integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
 
-debounce-fn@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.0.0.tgz#1375e6b64a871e6fb6967c6ee05efbac08b65d9e"
-  integrity sha512-y0u25m4GMdDJ1oHX4ziszas15E4ryNoeFkQuZM/Z6yTy8jB8ity/jqSNWnQUi/csBBaQIad6Zd8eI1xKwtbFzw==
-  dependencies:
-    mimic-fn "^3.0.0"
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -8410,13 +8354,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framesync@^4.0.0, framesync@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz#69a8db3ca432dc70d6a76ba882684a1497ef068a"
-  integrity sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==
-  dependencies:
-    hey-listen "^1.0.5"
-
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -9191,11 +9128,6 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hey-listen@^1.0.5, hey-listen@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
-  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 highlight.js@^10.1.1, highlight.js@~10.7.0:
   version "10.7.3"
@@ -11315,7 +11247,7 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-fn@^3.0.0, mimic-fn@^3.1.0:
+mimic-fn@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
@@ -15501,25 +15433,6 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-style-value-types@^3.1.7:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/style-value-types/-/style-value-types-3.2.0.tgz#eb89cab1340823fa7876f3e289d29d99c92111bb"
-  integrity sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==
-  dependencies:
-    hey-listen "^1.0.8"
-    tslib "^1.10.0"
-
-stylefire@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz#9120ecbb084111788e0ddaa04074799750f20d1d"
-  integrity sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==
-  dependencies:
-    "@popmotion/popcorn" "^0.4.4"
-    framesync "^4.0.0"
-    hey-listen "^1.0.8"
-    style-value-types "^3.1.7"
-    tslib "^1.10.0"
-
 stylis@^4.0.6:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
@@ -16607,22 +16520,10 @@ validator@^8.0.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
   integrity sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==
 
-value-enhancer@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/value-enhancer/-/value-enhancer-0.0.8.tgz#1e19655b678ddc3d93de61170e486e7f5b8e6f04"
-  integrity sha512-ba8Rcyp9ItqlLWoyZVqHGaEdY1tqP1mcbRhlOrCnIrDxdl8rKNH1Rq45syo4IMYNSkwC2oV9xBWcV9dmL14aQg==
-  dependencies:
-    side-effect-manager "^0.1.5"
-
 value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
-
-vanilla-lazyload@^17.5.0:
-  version "17.5.0"
-  resolved "https://registry.npmjs.org/vanilla-lazyload/-/vanilla-lazyload-17.5.0.tgz#ca2690fcf0627af3ad13e7fe41e7d0fac58d2a7e"
-  integrity sha512-1d2kjFT2BTrA2ynBBbJ58kIZqtB6TxocAvUFwmzjJ34RqLDlVPy4VmBDuAi6xgv+3LSmP6coKstU2eeRdI+ixw==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -16987,10 +16888,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.15.14:
-  version "2.15.14"
-  resolved "https://registry.yarnpkg.com/white-web-sdk/-/white-web-sdk-2.15.14.tgz#83601a4599fc228c05e45ef2cd963d80a3b844bc"
-  integrity sha512-sGmFjj8bM9yvF40TIM3zyqPv+fWNjqYK4ijCZG0p23l1BHBMFwuK140ivmc1YW0gn8+Rid0e3/kUzqnrHHBKvA==
+white-web-sdk@2.16.1:
+  version "2.16.1"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.16.1.tgz#b6a0151405601cf6d2cab3385eba03491f79b4b2"
+  integrity sha512-iFxlMwUZWLQd2r34AD1LpkJC2J8E9nqxxKxJfilQxLWZTE0AcpjhFiglKExSsA6ao7OuzGLgB/lMInJbykRqAA==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"


### PR DESCRIPTION
white-web-sdk: 
- feat:
  - listening change of custom scenes' sub scenes in the `displayer.createScenesCallback` methods
  - add `room.updateSelectedText`, `view.setSceneIndex` method
  - support Image rotation
  - deprecated api that such as`room.customInput`,`views.writableView`, `room.updateTextFontSize`
- fix:
  - multi-window mode:
    - the whiteboard mabey to automatic sizing
    - the `redo`, `undo` callback mabey to fail
    - the Canvas takes up too much memory
    - the whiteboard's readonly mode toggle to writable mode that `room.state.menberState` of whiteboard mabey not update
    - the Rectangle flashing when quick drag and drop rectangle tools 

window-manager:
- fix:
  - error of mainView sync scenes