### PR TITLE
build(storybook): remove unsupported storybook build args

### DIFF
--- a/packages/flat-components/package.json
+++ b/packages/flat-components/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "lint": "lint-staged",
     "start": "start-storybook -p 6006 -s public --no-version-updates",
-    "build": "build-storybook -s public --no-version-updates"
+    "build": "build-storybook -s public"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
https://github.com/storybookjs/storybook/search?q=updateCheck

Storybook has updated the structure of server cli. `build-storybook` no longer accepts `--no-version-updates`.