### PR TITLE
chore(library): upgrade white-web-sdk version to 2.16.3

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -46,7 +46,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.1"
+    "white-web-sdk": "2.16.3"
   },
   "devDependencies": {
     "@netless/eslint-plugin": "1.1.2",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -81,7 +81,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.1"
+    "white-web-sdk": "2.16.3"
   },
   "scripts": {
     "postinstall": "esbuild-dev ./scripts/post-install.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16903,10 +16903,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.16.1:
-  version "2.16.1"
-  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.16.1.tgz#b6a0151405601cf6d2cab3385eba03491f79b4b2"
-  integrity sha512-iFxlMwUZWLQd2r34AD1LpkJC2J8E9nqxxKxJfilQxLWZTE0AcpjhFiglKExSsA6ao7OuzGLgB/lMInJbykRqAA==
+white-web-sdk@2.16.3:
+  version "2.16.3"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.16.3.tgz#28679957980e9260a361ff3c6a3c886de37ddaa4"
+  integrity sha512-K6FsRsxiwOsIUbNPUzg73uWMUoMb3BH0h60b8FIDDAu8P75tKF3wssmClyp90Mc5dvrQJrGDJbPAUhDfgqpk3w==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"


### PR DESCRIPTION
fix: the whiteboard may have an offset and reprint when zooming or moving the view