### PR TITLE
chore(desktop): turn off vite eslint cache

### DIFF
--- a/desktop/renderer-app/vite.config.ts
+++ b/desktop/renderer-app/vite.config.ts
@@ -22,7 +22,9 @@ export default defineConfig(() => {
         refresh(),
         dotenv(configPath),
         electron(),
-        eslintPlugin(),
+        eslintPlugin({
+            cache: false,
+        }),
         copy({
             targets: [
                 /**


### PR DESCRIPTION
I got a corner case where some code was cached by the `vite-plugin-eslint` in electron environment.
I find a related issue with the plugin, see more detail [here](https://github.com/gxmari007/vite-plugin-eslint/issues/17).