### PR TITLE
chore(library): bump white-web-sdk from 2.16.6 to 2.16.8

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -45,7 +45,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.6"
+    "white-web-sdk": "2.16.9"
   },
   "devDependencies": {
     "@netless/eslint-plugin": "1.1.2",

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -80,7 +80,7 @@
     "react-virtualized": "^9.22.2",
     "uuid": "^8.3.2",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.6"
+    "white-web-sdk": "2.16.9"
   },
   "scripts": {
     "postinstall": "esbuild-dev ./scripts/post-install.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17003,10 +17003,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.16.6:
-  version "2.16.6"
-  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.16.6.tgz#0a1688cafb1b166ad6a8b08c3a613e654c48e3d6"
-  integrity sha512-N2Hmj5kCVcfpa006ItdYB4ckhARulptLFG0qIBG2xwvf0SizVHkzzjNu5Lpe7SQzjOSmhjE2q3HJZw1LMZH2JA==
+white-web-sdk@2.16.9:
+  version "2.16.9"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.16.9.tgz#6562fdbc25c78d76f4676c14893619c2a1e6b5c2"
+  integrity sha512-Qflz1OuHbcgd9ZjCVCB+sBSmFdOSMCA7qE02GYOiOffbdp4tHvrSjAbLtnDlb2Oije/he76OWK2Jyj0VUdBk/g==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"


### PR DESCRIPTION
- fix `insertText` api not working on safari
- improve writing performance on android
