### PR TITLE
fix(flat-components): fix the more btn show bug in home page room list

### DIFF
--- a/packages/flat-components/src/components/HomePage/RoomList/RoomListItem/style.less
+++ b/packages/flat-components/src/components/HomePage/RoomList/RoomListItem/style.less
@@ -1,5 +1,4 @@
 .room-list-item {
-    overflow: hidden;
     position: relative;
     border: 1px solid var(--grey-1);
     border-radius: 8px;
@@ -21,6 +20,7 @@
     display: flex;
     justify-content: space-between;
     padding: 8px;
+    border-radius: 8px;
     background-color: transparent;
     transition: background-color 0.4s;
 }


### PR DESCRIPTION
Fix the more btn show bug in home page room list.

Before: 
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/36325249/156182924-3bdefb02-1159-4692-bbd8-62fafc78aa8c.png">

After: 
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/36325249/156183184-f5f95841-d834-457a-a2f3-cefc1a2e47f5.png">