### PR TITLE
fix(flat-components): fix periodic room list bg bug

### DIFF
--- a/packages/flat-components/src/components/PeriodicRoomPage/index.less
+++ b/packages/flat-components/src/components/PeriodicRoomPage/index.less
@@ -1,8 +1,5 @@
 .periodic-room-panel-container {
-    width: 100%;
-    height: 100%;
     background-color: #fff;
-    overflow-y: auto;
 }
 
 .periodic-room-panel-body {

--- a/packages/flat-components/src/components/PeriodicRoomPage/index.less
+++ b/packages/flat-components/src/components/PeriodicRoomPage/index.less
@@ -2,6 +2,7 @@
     width: 100%;
     height: 100%;
     background-color: #fff;
+    overflow-y: auto;
 }
 
 .periodic-room-panel-body {


### PR DESCRIPTION
Fix periodic room list bg bug.

Before: 
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/36325249/156184620-b6eeda98-0f56-4914-9907-ab838f5a0b94.png">

After: 
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/36325249/156184684-1672d0f0-7081-4910-abdb-18b6be9d8800.png">
