### PR TITLE
fix(flat-components): incorrect teacher's chat avatar position

### DIFF
--- a/packages/flat-components/src/components/ChatPanel/ChatMessage/style.less
+++ b/packages/flat-components/src/components/ChatPanel/ChatMessage/style.less
@@ -6,7 +6,7 @@
         text-align: right;
 
         .chat-message-user {
-            justify-content: right;
+            justify-content: flex-end;
         }
     }
 }


### PR DESCRIPTION
Note: `justify-content: right` needs [chrome &ge; 93](https://caniuse.com/mdn-css_properties_justify-content_flex_context_left_right), while currently our electron has chrome 89.