### PR TITLE
Revert "feat(api): support set-cookie in login/process api"

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -57,8 +57,7 @@ module.exports = {
                 "style",
                 "room",
                 "classroom",
-                "assets",
-                "api",
+                "assets"
             ],
         ],
         "scope-case": [2, "always", ["lower-case", "kebab-case"]],

--- a/desktop/renderer-app/src/api-middleware/flatServer/index.ts
+++ b/desktop/renderer-app/src/api-middleware/flatServer/index.ts
@@ -495,13 +495,7 @@ export interface LoginProcessResult {
 }
 
 export async function loginProcess(authUUID: string): Promise<LoginProcessResult> {
-    return await postNotAuth<LoginProcessPayload, LoginProcessResult>(
-        "login/process",
-        {
-            authUUID,
-        },
-        {
-            withCredentials: true,
-        },
-    );
+    return await postNotAuth<LoginProcessPayload, LoginProcessResult>("login/process", {
+        authUUID,
+    });
 }

--- a/desktop/renderer-app/src/api-middleware/flatServer/utils.ts
+++ b/desktop/renderer-app/src/api-middleware/flatServer/utils.ts
@@ -48,8 +48,12 @@ export async function post<Payload, Result>(
 export async function postNotAuth<Payload, Result>(
     action: string,
     payload: Payload,
-    config?: AxiosRequestConfig,
+    params?: AxiosRequestConfig["params"],
 ): Promise<Result> {
+    const config: AxiosRequestConfig = {
+        params,
+    };
+
     const { data: res } = await Axios.post<FlatServerResponse<Result>>(
         `${FLAT_SERVER_VERSIONS.V1}/${action}`,
         payload,

--- a/web/flat-web/src/api-middleware/flatServer/index.ts
+++ b/web/flat-web/src/api-middleware/flatServer/index.ts
@@ -495,13 +495,7 @@ export interface LoginProcessResult {
 }
 
 export async function loginProcess(authUUID: string): Promise<LoginProcessResult> {
-    return await postNotAuth<LoginProcessPayload, LoginProcessResult>(
-        "login/process",
-        {
-            authUUID,
-        },
-        {
-            withCredentials: true,
-        },
-    );
+    return await postNotAuth<LoginProcessPayload, LoginProcessResult>("login/process", {
+        authUUID,
+    });
 }

--- a/web/flat-web/src/api-middleware/flatServer/utils.ts
+++ b/web/flat-web/src/api-middleware/flatServer/utils.ts
@@ -48,8 +48,12 @@ export async function post<Payload, Result>(
 export async function postNotAuth<Payload, Result>(
     action: string,
     payload: Payload,
-    config?: AxiosRequestConfig,
+    params?: AxiosRequestConfig["params"],
 ): Promise<Result> {
+    const config: AxiosRequestConfig = {
+        params,
+    };
+
     const { data: res } = await Axios.post<FlatServerResponse<Result>>(
         `${FLAT_SERVER_VERSIONS.V1}/${action}`,
         payload,


### PR DESCRIPTION
Reverts netless-io/flat#1448

Because:
```
Access to XMLHttpRequest at 'https://flat-api-dev.whiteboard.agora.io/v1/login/process' from origin 'https://flat-web-dev.whiteboard.agora.io' 
has been blocked by CORS policy: 
Response to preflight request doesn't pass access control check: 
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```