### PR TITLE
chore(whiteboard): upgrade fastboard to 0.3.4-canary.0

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -18,14 +18,14 @@
     "@netless/app-geogebra": "^0.0.4",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.14-beta.1",
-    "@netless/app-slide": "^0.2.0",
+    "@netless/app-slide": "^0.2.1",
     "@netless/combine-player": "^1.1.6",
-    "@netless/fastboard-react": "^0.3.3",
+    "@netless/fastboard-react": "^0.3.4-canary.1",
     "@netless/flat-rtc": "workspace:*",
     "@netless/flat-rtc-agora-electron": "workspace:*",
     "@netless/player-controller": "^0.0.9",
     "@netless/video-js-plugin": "^0.3.8",
-    "@netless/window-manager": "^0.4.25",
+    "@netless/window-manager": "^0.4.27-canary.0",
     "@videojs/vhs-utils": "^2.3.0",
     "agora-rtm-sdk": "^1.4.4",
     "antd": "^4.19.2",
@@ -57,7 +57,7 @@
     "uuid": "^8.3.2",
     "value-enhancer": "^1.0.3",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.21"
+    "white-web-sdk": "2.16.24"
   },
   "devDependencies": {
     "@types/classnames": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.0",
     "@commitlint/config-angular": "^17.0.0",
-    "@hyrious/esbuild-dev": "^0.7.4",
+    "@hyrious/esbuild-dev": "^0.7.6",
     "@netless/eslint-plugin": "^2.0.0",
-    "@netless/white-snapshot": "^0.3.1",
+    "@netless/white-snapshot": "^0.4.0",
     "@types/fs-extra": "^9.0.13",
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^17.0.21",
@@ -57,7 +57,7 @@
     "prettier": "^2.6.1",
     "svgo": "^2.8.0",
     "typescript": "^4.6.2",
-    "vite": "^2.9.9",
+    "vite": "^2.9.10",
     "webpack": "^5.70.0",
     "yaml": "^1.10.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,9 @@ importers:
     specifiers:
       '@commitlint/cli': ^17.0.0
       '@commitlint/config-angular': ^17.0.0
-      '@hyrious/esbuild-dev': ^0.7.4
+      '@hyrious/esbuild-dev': ^0.7.6
       '@netless/eslint-plugin': ^2.0.0
-      '@netless/white-snapshot': ^0.3.1
+      '@netless/white-snapshot': ^0.4.0
       '@types/fs-extra': ^9.0.13
       '@types/lodash-es': ^4.17.6
       '@types/node': ^17.0.21
@@ -48,15 +48,15 @@ importers:
       prettier: ^2.6.1
       svgo: ^2.8.0
       typescript: ^4.6.2
-      vite: ^2.9.9
+      vite: ^2.9.10
       webpack: ^5.70.0
       yaml: ^1.10.2
     devDependencies:
       '@commitlint/cli': 17.0.0
       '@commitlint/config-angular': 17.0.0
-      '@hyrious/esbuild-dev': 0.7.5_esbuild@0.14.38
+      '@hyrious/esbuild-dev': 0.7.6_esbuild@0.14.38
       '@netless/eslint-plugin': 2.0.0_eslint@8.14.0
-      '@netless/white-snapshot': 0.3.1
+      '@netless/white-snapshot': 0.4.0
       '@types/fs-extra': 9.0.13
       '@types/lodash-es': 4.17.6
       '@types/node': 17.0.31
@@ -89,7 +89,7 @@ importers:
       prettier: 2.6.2
       svgo: 2.8.0
       typescript: 4.6.4
-      vite: 2.9.9_less@4.1.2
+      vite: 2.9.10_less@4.1.2
       webpack: 5.72.0_esbuild@0.14.38
       yaml: 1.10.2
 
@@ -149,14 +149,14 @@ importers:
       '@netless/app-geogebra': ^0.0.4
       '@netless/app-iframe-bridge': ^0.0.2
       '@netless/app-monaco': ^0.1.14-beta.1
-      '@netless/app-slide': ^0.2.0
+      '@netless/app-slide': ^0.2.1
       '@netless/combine-player': ^1.1.6
-      '@netless/fastboard-react': ^0.3.3
+      '@netless/fastboard-react': ^0.3.4-canary.1
       '@netless/flat-rtc': workspace:*
       '@netless/flat-rtc-agora-electron': workspace:*
       '@netless/player-controller': ^0.0.9
       '@netless/video-js-plugin': ^0.3.8
-      '@netless/window-manager': ^0.4.25
+      '@netless/window-manager': ^0.4.27-canary.0
       '@types/classnames': ^2.3.0
       '@types/lodash': ^4.14.180
       '@types/node-downloader-helper': ^1.0.16
@@ -199,21 +199,21 @@ importers:
       uuid: ^8.3.2
       value-enhancer: ^1.0.3
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     dependencies:
       '@ant-design/icons': 4.7.0_sfoxds7t5ydpegc3knd667wn6m
       '@netless/app-countdown': 0.0.2
       '@netless/app-geogebra': 0.0.4
       '@netless/app-iframe-bridge': 0.0.2
       '@netless/app-monaco': 0.1.14-beta.1
-      '@netless/app-slide': 0.2.0
+      '@netless/app-slide': 0.2.1
       '@netless/combine-player': 1.1.6
-      '@netless/fastboard-react': 0.3.3_rnnxn3pchcsbkwbomkp7yrk3du
+      '@netless/fastboard-react': 0.3.4-canary.1_bhnimb6tlhvkqjz3si747tbj6m
       '@netless/flat-rtc': link:../../services/rtc/flat-rtc
       '@netless/flat-rtc-agora-electron': link:../../services/rtc/flat-rtc-agora-electron
-      '@netless/player-controller': 0.0.9_zsg5zubbw333nd3huiyxlfkssa
-      '@netless/video-js-plugin': 0.3.8_kcbubqpzr2jhwd7dwibcnybc2i
-      '@netless/window-manager': 0.4.25_white-web-sdk@2.16.21
+      '@netless/player-controller': 0.0.9_o7vtczmbhhex2z4p6q24qgrliu
+      '@netless/video-js-plugin': 0.3.8_vlvq6ga2kdzrhbgur7ypr5hode
+      '@netless/window-manager': 0.4.27-canary.0_white-web-sdk@2.16.24
       '@videojs/vhs-utils': 2.3.0
       agora-rtm-sdk: 1.4.4
       antd: 4.20.2_sfoxds7t5ydpegc3knd667wn6m
@@ -245,7 +245,7 @@ importers:
       uuid: 8.3.2
       value-enhancer: 1.0.3
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     devDependencies:
       '@types/classnames': 2.3.1
       '@types/lodash': 4.14.182
@@ -425,15 +425,15 @@ importers:
       '@netless/app-geogebra': ^0.0.4
       '@netless/app-iframe-bridge': ^0.0.2
       '@netless/app-monaco': ^0.1.14-beta.1
-      '@netless/app-slide': ^0.2.0
+      '@netless/app-slide': ^0.2.1
       '@netless/combine-player': ^1.1.6
-      '@netless/fastboard-react': ^0.3.3
+      '@netless/fastboard-react': ^0.3.4-canary.1
       '@netless/flat-rtc': workspace:*
       '@netless/flat-rtc-agora-web': workspace:*
       '@netless/mini-svg-data-uri': 0.0.1
       '@netless/player-controller': ^0.0.9
       '@netless/video-js-plugin': ^0.3.8
-      '@netless/window-manager': ^0.4.25
+      '@netless/window-manager': ^0.4.27-canary.0
       '@types/loadable__component': ^5.13.4
       '@types/mime': ^2.0.3
       '@videojs/vhs-utils': ^2.3.0
@@ -471,7 +471,7 @@ importers:
       uuid: ^8.3.2
       value-enhancer: ^1.0.3
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     dependencies:
       '@ant-design/icons': 4.7.0_sfoxds7t5ydpegc3knd667wn6m
       '@loadable/component': 5.15.2_react@17.0.2
@@ -479,14 +479,14 @@ importers:
       '@netless/app-geogebra': 0.0.4
       '@netless/app-iframe-bridge': 0.0.2
       '@netless/app-monaco': 0.1.14-beta.1
-      '@netless/app-slide': 0.2.0
+      '@netless/app-slide': 0.2.1
       '@netless/combine-player': 1.1.6
-      '@netless/fastboard-react': 0.3.3_rnnxn3pchcsbkwbomkp7yrk3du
+      '@netless/fastboard-react': 0.3.4-canary.1_bhnimb6tlhvkqjz3si747tbj6m
       '@netless/flat-rtc': link:../../services/rtc/flat-rtc
       '@netless/flat-rtc-agora-web': link:../../services/rtc/flat-rtc-agora-web
-      '@netless/player-controller': 0.0.9_zsg5zubbw333nd3huiyxlfkssa
-      '@netless/video-js-plugin': 0.3.8_kcbubqpzr2jhwd7dwibcnybc2i
-      '@netless/window-manager': 0.4.25_white-web-sdk@2.16.21
+      '@netless/player-controller': 0.0.9_o7vtczmbhhex2z4p6q24qgrliu
+      '@netless/video-js-plugin': 0.3.8_vlvq6ga2kdzrhbgur7ypr5hode
+      '@netless/window-manager': 0.4.27-canary.0_white-web-sdk@2.16.24
       '@videojs/vhs-utils': 2.3.0
       '@zip.js/zip.js': 2.4.10
       agora-rtc-sdk-ng: 4.11.0
@@ -518,7 +518,7 @@ importers:
       uuid: 8.3.2
       value-enhancer: 1.0.3
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     devDependencies:
       '@babel/standalone': 7.17.8
       '@netless/mini-svg-data-uri': 0.0.1
@@ -2021,6 +2021,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.9
 
+  /@babel/runtime/7.18.3:
+    resolution: {integrity: sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.9
+    dev: false
+
   /@babel/standalone/7.17.8:
     resolution: {integrity: sha512-tr3SDpVnxR/fzrxyG+HZPAyEA9eTHZIAjy4eqrc7m+KBwsdo1YvTbUfJ6teWHQ177mk6GmdmltsIiOYCcvRPWA==}
     engines: {node: '>=6.9.0'}
@@ -2665,8 +2672,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@hyrious/esbuild-dev/0.7.5_esbuild@0.14.38:
-    resolution: {integrity: sha512-VL883TyGJd5FiQpCnk/N4VkY5sUZuhid341+YRQUyisq5uiAavpygNSNO80e5zWrssNMrrSR0SMoFHy++RAnkg==}
+  /@hyrious/esbuild-dev/0.7.6_esbuild@0.14.38:
+    resolution: {integrity: sha512-ULrwpkaXG7RLg8u7Zd3y8feJqyL9lpy5hv848/33Swa9EXT02uvABrPPdNczyLln3DAlKnwy2Up9K8B/ZcphWw==}
     engines: {node: '>=16.13.0'}
     hasBin: true
     peerDependencies:
@@ -2880,8 +2887,8 @@ packages:
     resolution: {integrity: sha512-Rlig/UX4dZosv/VWslJRCxm7H9ufZ0TeEZK4krMEVCf+SnEHZsn1HUbbpoTQeead78k3scoaF5fC9wE/chORyQ==}
     dev: false
 
-  /@netless/app-slide/0.2.0:
-    resolution: {integrity: sha512-kKJyTVLE4pWLzhjllw7tNEZ42ghBgBiSMA1HtsUbzTBRHb2869oD/Jd+nLW9i59411yyg9TCF9hJckamozHbew==}
+  /@netless/app-slide/0.2.1:
+    resolution: {integrity: sha512-HTwxmkesTLizr5lc0vouCxjSNmPcGOMGFC036y2AE13WdYJOfouUa/aZz08nawNijCi2W9Kh4wc2wzvf1s2Y/g==}
     dev: false
 
   /@netless/canvas-polyfill/0.0.4:
@@ -2904,36 +2911,36 @@ packages:
       - supports-color
     dev: true
 
-  /@netless/fastboard-core/0.3.3_t5kp6kxigevktvq2yb4wuhnt7e:
-    resolution: {integrity: sha512-Iayvp0K+9NHp/mfCLNbgIqUSetOmMq4D1hUQwNp/r5MIIV8yX/i8JBL+DzxAueD8zsyLV1itTbf6I9rAzRcqug==}
+  /@netless/fastboard-core/0.3.4-canary.1_2ns3czg5oyyeu5g3g4pimolequ:
+    resolution: {integrity: sha512-x0iUzMojwDcQKwsMosWIXQzjarMyvqSVu31iHl4PzGMhoa1MIhXflDhN+S/PVy3a1YluLTStHC8mmb2Fo8FZiQ==}
     peerDependencies:
       '@netless/window-manager': '>=0.4.0'
       white-web-sdk: '>=2.16.0'
     dependencies:
-      '@netless/app-slide': 0.2.0
-      '@netless/window-manager': 0.4.25_white-web-sdk@2.16.21
-      white-web-sdk: 2.16.21
+      '@netless/app-slide': 0.2.1
+      '@netless/window-manager': 0.4.27-canary.0_white-web-sdk@2.16.24
+      white-web-sdk: 2.16.24
     dev: false
 
-  /@netless/fastboard-react/0.3.3_rnnxn3pchcsbkwbomkp7yrk3du:
-    resolution: {integrity: sha512-enlVUX9F2nWWDeJvT2S2ggmj+H8vlvWWM4GfAVh7wPMAEmIHtXtIkJBmv8dTTQ5uNCODPvup1rt8fba6y5odDA==}
+  /@netless/fastboard-react/0.3.4-canary.1_bhnimb6tlhvkqjz3si747tbj6m:
+    resolution: {integrity: sha512-5StotjWxEFZvusNTJY3kBhO7UVcLbP27kNX715pUtl1aZXP0Wf6RhImGMkrtOHxjSBM8z5DxOuQ9jlna4JJa8Q==}
     peerDependencies:
       react: '*'
     dependencies:
-      '@netless/fastboard-core': 0.3.3_t5kp6kxigevktvq2yb4wuhnt7e
-      '@netless/fastboard-ui': 0.3.3_cwdgvhe2rjhzeo33ldxoblopem
+      '@netless/fastboard-core': 0.3.4-canary.1_2ns3czg5oyyeu5g3g4pimolequ
+      '@netless/fastboard-ui': 0.3.4-canary.1_j6ftqatmwo6ju5monbs5igwake
       react: 17.0.2
     transitivePeerDependencies:
       - '@netless/window-manager'
       - white-web-sdk
     dev: false
 
-  /@netless/fastboard-ui/0.3.3_cwdgvhe2rjhzeo33ldxoblopem:
-    resolution: {integrity: sha512-JgMVHz0mOG/nfKA8Lhur4B43FTj24qVqNqeIKb5T24C0XES+wONTKIjK1pGCtiLhJFMU4ikxPBV8HnHiX1XG0Q==}
+  /@netless/fastboard-ui/0.3.4-canary.1_j6ftqatmwo6ju5monbs5igwake:
+    resolution: {integrity: sha512-oKU4KhFl88loJJXThPW3xQeS7ZVFLBWbXSiSnjZTOFETNY3qqM5dWbtvAp5XVzlxazDCKNHQCSf5YJPIWpxPXQ==}
     peerDependencies:
-      '@netless/fastboard-core': 0.3.3
+      '@netless/fastboard-core': 0.3.4-canary.1
     dependencies:
-      '@netless/fastboard-core': 0.3.3_t5kp6kxigevktvq2yb4wuhnt7e
+      '@netless/fastboard-core': 0.3.4-canary.1_2ns3czg5oyyeu5g3g4pimolequ
       tippy.js: 6.3.7
     dev: false
 
@@ -2942,7 +2949,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@netless/player-controller/0.0.9_zsg5zubbw333nd3huiyxlfkssa:
+  /@netless/player-controller/0.0.9_o7vtczmbhhex2z4p6q24qgrliu:
     resolution: {integrity: sha512-n+30ug/DMYsGI6awfe0JP8JxgQto3FN20V5IPkDZjXfo2vXfeySkGTE9/36r67p9UV4e19uiF5wq8BsG73Ra3A==}
     peerDependencies:
       antd: 4.x
@@ -2955,7 +2962,7 @@ packages:
       antd: 4.20.2_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     dev: false
 
   /@netless/telebox-insider/0.2.26:
@@ -2969,7 +2976,7 @@ packages:
       value-enhancer: 0.0.8
     dev: false
 
-  /@netless/video-js-plugin/0.3.8_kcbubqpzr2jhwd7dwibcnybc2i:
+  /@netless/video-js-plugin/0.3.8_vlvq6ga2kdzrhbgur7ypr5hode:
     resolution: {integrity: sha512-xCLfL8ISjPD5XQbeGWT/pwKdWXqYXmaEXiP4jcX8oaR83+vJo463znIg2JW8EXHkTq7KRrYnZqqlQdI6It4L+A==}
     peerDependencies:
       react: '>=16 || ^17'
@@ -2980,15 +2987,17 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     dev: false
 
-  /@netless/white-snapshot/0.3.1:
-    resolution: {integrity: sha512-Ztm9NeHtjz4r0krZxhWWbEJg43c2elcii9rV7ZF+J12FZKUY3J9dUuKa0BpQVgnFYojsa8X0zPaLyrVtS5rHSA==}
+  /@netless/white-snapshot/0.4.0:
+    resolution: {integrity: sha512-jrh6Iq4I6jO2TfBCNGsomnGa+jc0qjjvfgOi2Tyyj5/4SwYIkXDOr4e4TnRg0VMtfH4vDfSbTsSIsKxewgQOCw==}
+    dependencies:
+      html2canvas: 1.4.1
     dev: true
 
-  /@netless/window-manager/0.4.25_white-web-sdk@2.16.21:
-    resolution: {integrity: sha512-sQpGFmhNscOmL2JVckKwIfEOmsj/dhfH12w5H6e0yRPuuRkZ1KjypX6+6F5NGVzRpeoKkIFs7QOa5ifpgMVNRA==}
+  /@netless/window-manager/0.4.27-canary.0_white-web-sdk@2.16.24:
+    resolution: {integrity: sha512-bhNqotgKytI/nIFKBnuwvHopYgm+B/ZS5IUNNXhZcMlIOpKZwJV/Do6pbBe8IJf6ibqtKH01jasj2EjYLWMoQg==}
     peerDependencies:
       white-web-sdk: ^2.16.0
     dependencies:
@@ -3000,7 +3009,7 @@ packages:
       side-effect-manager: 0.1.5
       uuid: 7.0.3
       video.js: 7.10.2
-      white-web-sdk: 2.16.21
+      white-web-sdk: 2.16.24
     dev: false
 
   /@netless/xml-js/1.6.15:
@@ -4894,6 +4903,11 @@ packages:
 
   /@types/node/17.0.34:
     resolution: {integrity: sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==}
+    dev: true
+
+  /@types/node/17.0.40:
+    resolution: {integrity: sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg==}
+    dev: false
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5719,6 +5733,8 @@ packages:
       shelljs: 0.8.5
       yuv-buffer: 1.0.0
       yuv-canvas: 1.2.11
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /agora-rtc-sdk-ng/4.11.0:
@@ -6593,6 +6609,11 @@ packages:
       pascalcase: 0.1.1
     dev: true
 
+  /base64-arraybuffer/1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+    dev: true
+
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -6680,6 +6701,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /boolbase/1.0.0:
@@ -6749,6 +6772,8 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /braces/3.0.2:
@@ -7386,7 +7411,7 @@ packages:
     dev: true
 
   /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -7526,6 +7551,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /compute-scroll-into-view/1.0.17:
@@ -7671,8 +7698,8 @@ packages:
     requiresBuild: true
     dev: true
 
-  /core-js/3.22.5:
-    resolution: {integrity: sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==}
+  /core-js/3.22.8:
+    resolution: {integrity: sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA==}
     requiresBuild: true
     dev: false
 
@@ -7936,6 +7963,12 @@ packages:
       isobject: 3.0.1
     dev: false
 
+  /css-line-break/2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+    dependencies:
+      utrie: 1.0.2
+    dev: true
+
   /css-loader/3.6.0_webpack@4.46.0:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
@@ -8108,6 +8141,18 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 5.5.0
+    dev: true
+
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -8149,7 +8194,7 @@ packages:
     dev: false
 
   /decode-uri-component/0.2.0:
-    resolution: {integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=}
+    resolution: {integrity: sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==}
     engines: {node: '>=0.10'}
 
   /decompress-response/3.3.0:
@@ -8357,6 +8402,8 @@ packages:
     dependencies:
       address: 1.2.0
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /detect-port/1.3.0:
@@ -8366,6 +8413,8 @@ packages:
     dependencies:
       address: 1.2.0
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /detect-touch-events/2.0.2:
@@ -8729,6 +8778,8 @@ packages:
       isbinaryfile: 3.0.3
       minimist: 1.2.6
       plist: 3.0.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /electron-publish/23.0.2:
@@ -9340,6 +9391,8 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-loader/4.0.2:
@@ -9915,6 +9968,8 @@ packages:
       debug: 2.6.9
       mkdirp: 0.5.6
       yauzl: 2.10.0
+    transitivePeerDependencies:
+      - supports-color
 
   /extract-zip/2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -10179,6 +10234,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /find-cache-dir/2.1.0:
@@ -11401,6 +11458,14 @@ packages:
       webpack: 5.72.0
     dev: true
 
+  /html2canvas/1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    dev: true
+
   /htmlparser2/6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
     dependencies:
@@ -11567,7 +11632,7 @@ packages:
     dev: true
 
   /image-size/0.5.5:
-    resolution: {integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=}
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
@@ -12253,7 +12318,7 @@ packages:
     dev: true
 
   /javascript-natural-sort/0.7.1:
-    resolution: {integrity: sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=}
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
     dev: false
 
   /jest-haste-map/26.6.2:
@@ -12628,6 +12693,8 @@ packages:
       mime: 1.6.0
       needle: 2.9.1
       source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /levn/0.3.0:
@@ -12968,12 +13035,12 @@ packages:
     dev: true
     optional: true
 
-  /mathjs/10.5.3:
-    resolution: {integrity: sha512-RtF+F7SdRIf2E2+btyGDhuB6wmPjOH9KeNglfclaaaI6eK7ZNfsQS6IRAKvGyNsr8sFc6Pyb3JBLqEhYBuknVQ==}
+  /mathjs/10.6.1:
+    resolution: {integrity: sha512-8iZp6uUKKBoCFoUHze9ydsrSji9/IOEzMhwURyoQXaLL1+ILEZnraw4KzZnUBt/XN6lPJPV+7JO94oil3AmosQ==}
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.18.3
       complex.js: 2.1.1
       decimal.js: 10.3.1
       escape-latex: 1.2.0
@@ -13371,6 +13438,10 @@ packages:
     resolution: {integrity: sha512-pHZ/cySF00FVENDWIDzJyoObFahK6Eg4d0papqm6d7yMkxWTZ/S/csqJX1A3PsYy4t5k3z2QnlwuCfMW5lSEwA==}
     dev: false
 
+  /mobx/6.6.0:
+    resolution: {integrity: sha512-MNTKevLH/6DShLZcmSL351+JgiJPO56A4GUpoiDQ3/yZ0mAtclNLdHK9q4BcQhibx8/JSDupfTpbX2NZPemlRg==}
+    dev: false
+
   /moment/2.29.3:
     resolution: {integrity: sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==}
 
@@ -13495,6 +13566,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /native-url/0.2.6:
@@ -13521,6 +13594,8 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
     optional: true
 
@@ -13649,7 +13724,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -14616,6 +14691,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss/8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /prelude-ls/1.1.2:
     resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
     engines: {node: '>= 0.8.0'}
@@ -14773,8 +14857,8 @@ packages:
   /proto-list/1.2.4:
     resolution: {integrity: sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=}
 
-  /protobufjs/6.11.2:
-    resolution: {integrity: sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==}
+  /protobufjs/6.11.3:
+    resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==}
     hasBin: true
     requiresBuild: true
     dependencies:
@@ -14789,7 +14873,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 17.0.34
+      '@types/node': 17.0.40
       long: 4.0.0
     dev: false
 
@@ -16478,8 +16562,8 @@ packages:
       yargs: 17.4.1
     dev: true
 
-  /rollup/2.73.0:
-    resolution: {integrity: sha512-h/UngC3S4Zt28mB3g0+2YCMegT5yoftnQplwzPqGZcKvlld5e+kT/QRmJiL+qxGyZKOYpgirWGdLyEO1b0dpLQ==}
+  /rollup/2.75.5:
+    resolution: {integrity: sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -16742,6 +16826,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serialize-error/7.0.1:
@@ -16789,6 +16875,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /set-blocking/2.0.0:
@@ -16964,6 +17052,8 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /socks-proxy-agent/5.0.1:
@@ -17843,6 +17933,12 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /text-segmentation/1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+    dependencies:
+      utrie: 1.0.2
+    dev: true
+
   /text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
@@ -18675,6 +18771,12 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
+  /utrie/1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    dev: true
+
   /uuid-browser/3.1.0:
     resolution: {integrity: sha1-DwWkCu90+eWVHiDvv0SxGHHlZBA=}
     dev: true
@@ -18804,8 +18906,8 @@ packages:
       global: 4.4.0
     dev: false
 
-  /vite/2.9.9_less@4.1.2:
-    resolution: {integrity: sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==}
+  /vite/2.9.10_less@4.1.2:
+    resolution: {integrity: sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -18822,9 +18924,9 @@ packages:
     dependencies:
       esbuild: 0.14.38
       less: 4.1.2
-      postcss: 8.4.13
+      postcss: 8.4.14
       resolve: 1.22.0
-      rollup: 2.73.0
+      rollup: 2.75.5
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -19045,6 +19147,8 @@ packages:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
       debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /webpack-virtual-modules/0.4.3:
@@ -19213,8 +19317,8 @@ packages:
     dependencies:
       isexe: 2.0.0
 
-  /white-web-sdk/2.16.21:
-    resolution: {integrity: sha512-19xdaZu7/qXrc2bhN4Y976VCooymkhXnUrLi2a7UQbHfTPOxaLh4LgNPNzgbjpjkX600LnsV3SlWwzwd9+Dmqw==}
+  /white-web-sdk/2.16.24:
+    resolution: {integrity: sha512-onauWjDLcoOHN5lELmV8vjGU5Mrgi3KaWxI6obciMPQXDrzUPljyosRUPqC0i5BM+xn3oIn8s53yX+J/IOtAKA==}
     dependencies:
       '@juggle/resize-observer': 3.3.1
       '@netless/canvas-polyfill': 0.0.4
@@ -19222,12 +19326,12 @@ packages:
       atob: 2.1.2
       bezier-js: 2.6.1
       color: 3.2.1
-      core-js: 3.22.5
+      core-js: 3.22.8
       detect-it: 3.0.7
       eventemitter3: 4.0.7
-      mathjs: 10.5.3
-      mobx: 6.5.0
-      protobufjs: 6.11.2
+      mathjs: 10.6.1
+      mobx: 6.6.0
+      protobufjs: 6.11.3
       query-string: 5.1.1
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -18,14 +18,14 @@
     "@netless/app-geogebra": "^0.0.4",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "^0.1.14-beta.1",
-    "@netless/app-slide": "^0.2.0",
+    "@netless/app-slide": "^0.2.1",
     "@netless/combine-player": "^1.1.6",
-    "@netless/fastboard-react": "^0.3.3",
+    "@netless/fastboard-react": "^0.3.4-canary.1",
     "@netless/flat-rtc": "workspace:*",
     "@netless/flat-rtc-agora-web": "workspace:*",
     "@netless/player-controller": "^0.0.9",
     "@netless/video-js-plugin": "^0.3.8",
-    "@netless/window-manager": "^0.4.25",
+    "@netless/window-manager": "^0.4.27-canary.0",
     "@videojs/vhs-utils": "^2.3.0",
     "@zip.js/zip.js": "^2.4.6",
     "agora-rtc-sdk-ng": "^4.9.4",
@@ -57,7 +57,7 @@
     "uuid": "^8.3.2",
     "value-enhancer": "^1.0.3",
     "video.js": "7.10.2",
-    "white-web-sdk": "2.16.21"
+    "white-web-sdk": "2.16.24"
   },
   "devDependencies": {
     "@babel/standalone": "7.17.8",


### PR DESCRIPTION
chore(whiteboard): upgrade fastboard to 0.3.4-canary.1

- @netless/fastboard 0.3.4-canary.1: make the Fastboard component immutable
- @netless/app-slide 0.2.1: fix an offline error in vanilla-lazyload
- @netless/window-manager 0.4.27-canary.0: add `removePage`
- @netless/white-snapshot 0.4.0: add back html2canvas to fix images
- white-web-sdk 2.16.24: fix virtual keyboard not working on iOS