### PR TITLE
fix(flat-components): close popover when click popMenu element

### DIFF
--- a/packages/flat-components/src/components/DeviceTestPage/CameraTest/style.less
+++ b/packages/flat-components/src/components/DeviceTestPage/CameraTest/style.less
@@ -7,6 +7,7 @@
     height: 240px;
     width: 100%;
     position: relative;
+    overflow: hidden;
     border-radius: 6px;
     background-color: #000;
 }

--- a/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/index.tsx
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageNavAvatar/index.tsx
@@ -66,6 +66,7 @@ export const MainPageNavAvatar: React.FC<MainPageNavAvatarProps> = ({
                             onClick={e => {
                                 e.preventDefault();
                                 onClick(menuItem);
+                                togglePopMenuVisible();
                             }}
                         >
                             <span className="main-page-pop-menu-item-icon">


### PR DESCRIPTION
- style(flat-components): camera screen is too large