### PR TITLE
chore(flat-components): fix after being banned the teacher terminal d…

### DIFF
--- a/packages/flat-components/src/components/ChatPanel/ChatTypeBox/index.tsx
+++ b/packages/flat-components/src/components/ChatPanel/ChatTypeBox/index.tsx
@@ -74,7 +74,7 @@ export const ChatTypeBox = observer<ChatTypeBoxProps>(function ChatTypeBox({
             )}
             <button
                 className="chat-typebox-send"
-                disabled={isBan || isSending || trimmedText.length <= 0}
+                disabled={(!isCreator && isBan) || isSending || trimmedText.length <= 0}
                 title={t("send")}
                 onClick={sendMessage}
             >


### PR DESCRIPTION
 fix after being banned the teacher terminal does not display send button

before:
`press send buttom can't send message, but press Enter can send message`

<img width="392" alt="image" src="https://user-images.githubusercontent.com/47295879/185738196-598a947b-9667-4011-9a00-3b0d3e5ae338.png">


after:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/47295879/185738256-90993b99-4747-4164-99b7-93c7b56cd79e.png">
