### PR TITLE
Sync hotfix stable

### DIFF
--- a/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/index.tsx
+++ b/packages/flat-components/src/components/ClassroomPage/CloudRecordBtn/index.tsx
@@ -1,20 +1,23 @@
-import { observer } from "mobx-react-lite";
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { useTranslate } from "@netless/flat-i18n";
+
 import { TopBarRightBtn } from "../TopBar";
 import { SVGRecord, SVGRecordStop } from "../../FlatIcons";
 
 export type CloudRecordBtnProps = {
+    loading?: boolean;
     isRecording: boolean;
-    onClick: (evt: any) => void;
+    onClick: () => void;
 };
 
 export const CloudRecordBtn: React.FC<CloudRecordBtnProps> = /* @__PURE__ */ observer(
-    ({ isRecording, onClick }) => {
+    ({ loading, isRecording, onClick }) => {
         const t = useTranslate();
 
         return (
             <TopBarRightBtn
+                disabled={loading}
                 icon={isRecording ? <SVGRecordStop active /> : <SVGRecord />}
                 title={t("recording")}
                 onClick={onClick}

--- a/packages/flat-pages/src/BigClassPage/index.tsx
+++ b/packages/flat-pages/src/BigClassPage/index.tsx
@@ -130,6 +130,7 @@ export const BigClassPage = withClassroomStore<BigClassPageProps>(
                     {classroomStore.isCreator && (
                         <CloudRecordBtn
                             isRecording={classroomStore.isRecording}
+                            loading={classroomStore.isRecordingLoading}
                             onClick={() => {
                                 void classroomStore.toggleRecording({
                                     onStop() {

--- a/packages/flat-pages/src/OneToOnePage/index.tsx
+++ b/packages/flat-pages/src/OneToOnePage/index.tsx
@@ -124,6 +124,7 @@ export const OneToOnePage = withClassroomStore<OneToOnePageProps>(
                     {classroomStore.isCreator && (
                         <CloudRecordBtn
                             isRecording={classroomStore.isRecording}
+                            loading={classroomStore.isRecordingLoading}
                             onClick={() => {
                                 void classroomStore.toggleRecording({
                                     onStop() {

--- a/packages/flat-pages/src/SmallClassPage/index.tsx
+++ b/packages/flat-pages/src/SmallClassPage/index.tsx
@@ -193,6 +193,7 @@ export const SmallClassPage = withClassroomStore<SmallClassPageProps>(
                     {classroomStore.isCreator && (
                         <CloudRecordBtn
                             isRecording={classroomStore.isRecording}
+                            loading={classroomStore.isRecordingLoading}
                             onClick={() => {
                                 void classroomStore.toggleRecording({
                                     onStop() {

--- a/packages/flat-pages/src/utils/drag-and-drop/image.ts
+++ b/packages/flat-pages/src/utils/drag-and-drop/image.ts
@@ -1,6 +1,6 @@
 import { message } from "antd";
 import { v4 as v4uuid } from "uuid";
-import type { ApplianceNames, Room, Size } from "white-web-sdk";
+import { ApplianceNames, Room, Size } from "white-web-sdk";
 import { listFiles } from "@netless/flat-server-api";
 import { UploadTask } from "@netless/flat-stores";
 import { FlatI18n } from "@netless/flat-i18n";

--- a/packages/flat-services/src/services/file/file-insert/file-insert.ts
+++ b/packages/flat-services/src/services/file/file-insert/file-insert.ts
@@ -1,6 +1,13 @@
 import { CloudFile } from "@netless/flat-server-api";
 import { IService } from "../../typing";
 
+export interface IServiceFileInsertOptions {
+    coord?: {
+        clientX: number;
+        clientY: number;
+    };
+}
+
 export interface IServiceFileInsert extends IService {
-    insert(file: CloudFile): Promise<any>;
+    insert(file: CloudFile, options?: IServiceFileInsertOptions): Promise<any>;
 }

--- a/packages/flat-stores/src/classroom-store/index.ts
+++ b/packages/flat-stores/src/classroom-store/index.ts
@@ -57,6 +57,8 @@ export class ClassroomStore {
     public isBan = false;
     /** is Cloud Recording on */
     public isRecording = false;
+    /** is toggling cloud recording */
+    public isRecordingLoading = false;
     /** is user login on other device */
     public isRemoteLogin = false;
 
@@ -478,6 +480,7 @@ export class ClassroomStore {
     };
 
     public toggleRecording = async ({ onStop }: { onStop?: () => void } = {}): Promise<void> => {
+        this.isRecordingLoading = true;
         try {
             if (this.isRecording) {
                 await this.stopRecording();
@@ -488,6 +491,9 @@ export class ClassroomStore {
         } catch (e) {
             errorTips(e as Error);
         }
+        runInAction(() => {
+            this.isRecordingLoading = false;
+        });
     };
 
     public updateClassMode = (classMode?: ClassModeType): void => {


### PR DESCRIPTION
What's included in this PR:

- cheery-pick #1628, add loading state to cloud record button.

  However, cloud recording has not been implemented in main branch, so this commit only tweaks UI.

- cheery-pick #1629, but add an extra option to fastboard service.

TODO:

- Implement cloud recording properly, which requires @BlackHole1 and @crimx to work it out. Refer to #1629 and #1634 for more details.

- Implement the whiteboard component (should be in fastboard service) properly, it includes functions like drag-and-drop. Refer to Whiteboard.tsx for more details.