### PR TITLE
chore(service-providers): fix the inconsistency of video effects between teachers and students

### DIFF
--- a/service-providers/agora-rtc/agora-rtc-web/src/rtc-remote-avatar.ts
+++ b/service-providers/agora-rtc/agora-rtc-web/src/rtc-remote-avatar.ts
@@ -82,7 +82,9 @@ export class RTCRemoteAvatar implements IServiceVideoChatAvatar {
                             try {
                                 if (shouldCamera) {
                                     if (!videoTrack.isPlaying) {
-                                        videoTrack.play(el);
+                                        videoTrack.play(el, {
+                                            mirror: true,
+                                        });
                                         // dispose this track on next track update
                                         disposer = () => videoTrack.stop();
                                     }


### PR DESCRIPTION
reference：
https://docs.agora.io/cn/video-call-4.x/API%20Reference/web_ng/interfaces/videoplayerconfig.html#mirror

本地视频轨道默认开启镜像模式，远程视频轨道默认关闭镜像模式，导致师生两边视频显示效果相反，如果老师需要通过视频表达一些方向性的知识会不会产生矛盾


