### PR TITLE
refactor(service-providers): use 384x216 (16:9) source video

### DIFF
--- a/packages/flat-pages/src/components/UserWindows.tsx
+++ b/packages/flat-pages/src/components/UserWindows.tsx
@@ -7,7 +7,7 @@ import { ClassroomStore, UserWindow } from "@netless/flat-stores";
 import { AvatarWindow, fixRect, Rectangle, ResizeHandle, useIsUnMounted } from "flat-components";
 import { WHITEBOARD_RATIO } from "@netless/flat-stores/src/constants";
 
-const WINDOW_RATIO = 3 / 4;
+const WINDOW_RATIO = 9 / 16;
 const DEFAULT_WIDTH_P = 0.4;
 const MIN_WIDTH_P = 0.25;
 
@@ -100,6 +100,12 @@ export const UserWindows = observer<UserWindowsProps>(function UserWindows({ cla
                 "is-hovering": hovering,
             })}
             data-size={userWindowsLength}
+            style={{
+                paddingLeft: baseRect.extraX,
+                paddingRight: baseRect.extraX,
+                paddingTop: baseRect.extraY,
+                paddingBottom: baseRect.extraY,
+            }}
         >
             {users.map(({ userUUID, window }) => (
                 <UserAvatarWindow
@@ -134,7 +140,7 @@ interface UserAvatarWindowProps {
     classroom: ClassroomStore;
 }
 
-const DEFAULT_WINDOW: UserWindow = { x: 0, y: 0, width: 0.4, height: 8 / 15, z: 0 };
+const DEFAULT_WINDOW: UserWindow = { x: 0, y: 0, width: 0.4, height: 0.4 * WINDOW_RATIO, z: 0 };
 
 const UserAvatarWindow = observer<UserAvatarWindowProps>(function UserAvatarWindow({
     mode,

--- a/service-providers/agora-cloud-recording/src/constants.ts
+++ b/service-providers/agora-cloud-recording/src/constants.ts
@@ -23,7 +23,7 @@ export type RecordingConfig = AgoraCloudRecordStartRequestBody["clientRequest"][
 export const BIG_CLASS_RECORDING_CONFIG: RecordingConfig = {
     channelType: AgoraCloudRecordingChannelType.Broadcast,
     transcodingConfig: {
-        width: 288,
+        width: 384,
         height: 216,
         fps: 15,
         bitrate: 280,
@@ -81,7 +81,7 @@ export const SMALL_CLASS_RECORDING_CONFIG: RecordingConfig = {
 export const ONE_TO_ONE_RECORDING_CONFIG: RecordingConfig = {
     channelType: AgoraCloudRecordingChannelType.Communication,
     transcodingConfig: {
-        width: 288,
+        width: 384,
         height: 216,
         fps: 15,
         bitrate: 140,

--- a/service-providers/agora-rtc/agora-rtc-electron/src/agora-rtc-electron.ts
+++ b/service-providers/agora-rtc/agora-rtc-electron/src/agora-rtc-electron.ts
@@ -422,7 +422,7 @@ export class AgoraRTCElectron extends IServiceVideoChat {
             mirrorMode: 0,
             orientationMode: 0,
             height: 216,
-            width: 288,
+            width: 384,
         });
 
         if (mode === IServiceVideoChatMode.Broadcast) {

--- a/service-providers/agora-rtc/agora-rtc-web/src/agora-rtc-web.ts
+++ b/service-providers/agora-rtc/agora-rtc-web/src/agora-rtc-web.ts
@@ -481,7 +481,7 @@ export class AgoraRTCWeb extends IServiceVideoChat {
     public createLocalCameraTrack = singleRun(async (): Promise<ICameraVideoTrack> => {
         if (!this.localCameraTrack) {
             this.localCameraTrack = await AgoraRTC.createCameraVideoTrack({
-                encoderConfig: { width: 288, height: 216 },
+                encoderConfig: { width: 384, height: 216 },
                 cameraId: this._cameraID,
             });
 


### PR DESCRIPTION
- refactor(flat-pages): squash avatars to center on grid mode
