### PR TITLE
chore(library): upgrade window-manager to 1.0.0-canary.77

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -17,17 +17,23 @@ jobs:
     runs-on: macos-latest
 
     concurrency:
-      group: ci-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
+
+      - name: Restore Cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
 
       - name: Install changed package dependencies and build packages
         run: |-

--- a/.github/workflows/check-spell.yml
+++ b/.github/workflows/check-spell.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 18
 
       - name: Install cspell
         run:  npm i -g cspell

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "packages/flat-components/src/**"
 
+permissions:
+  contents: write
+
 jobs:
   deploy-storybook:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,12 +12,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
+
+      - name: Restore Cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
 
       - name: Install dependencies
         run: |-

--- a/.github/workflows/deploy-web-dev-cn.yml
+++ b/.github/workflows/deploy-web-dev-cn.yml
@@ -15,12 +15,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
+
+      - name: Restore Cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-web-dev-us.yml
+++ b/.github/workflows/deploy-web-dev-us.yml
@@ -15,12 +15,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
+
+      - name: Restore Cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-web-prod-cn.yml
+++ b/.github/workflows/deploy-web-prod-cn.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-web-prod-us.yml
+++ b/.github/workflows/deploy-web-prod-us.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: latest
 
       - name: Install dependencies
         run: |

--- a/packages/flat-stores/package.json
+++ b/packages/flat-stores/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@netless/fastboard": "1.0.0-canary.8",
-    "@netless/window-manager": "1.0.0-canary.76",
+    "@netless/window-manager": "1.0.0-canary.77",
     "mobx": "^6.6.1",
     "prettier": "^2.7.1",
     "react": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 neverBuiltDependencies:
   - agora-electron-sdk
@@ -799,10 +803,10 @@ importers:
     devDependencies:
       '@netless/fastboard':
         specifier: 1.0.0-canary.8
-        version: 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41)
+        version: 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41)
       '@netless/window-manager':
-        specifier: 1.0.0-canary.76
-        version: 1.0.0-canary.76(white-web-sdk-esm@2.16.41)
+        specifier: 1.0.0-canary.77
+        version: 1.0.0-canary.77(white-web-sdk-esm@2.16.41)
       mobx:
         specifier: ^6.6.1
         version: 6.6.2
@@ -953,7 +957,7 @@ importers:
         version: 2.0.0
       '@netless/fastboard':
         specifier: 1.0.0-canary.8
-        version: 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41)
+        version: 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41)
       '@netless/flat-i18n':
         specifier: workspace:*
         version: link:../../packages/flat-i18n
@@ -970,8 +974,8 @@ importers:
         specifier: ^0.4.2
         version: 0.4.2
       '@netless/window-manager':
-        specifier: 1.0.0-canary.76
-        version: 1.0.0-canary.76(white-web-sdk-esm@2.16.41)
+        specifier: 1.0.0-canary.77
+        version: 1.0.0-canary.77(white-web-sdk-esm@2.16.41)
       side-effect-manager:
         specifier: ^1.2.1
         version: 1.2.1
@@ -3755,7 +3759,7 @@ packages:
       - supports-color
     dev: true
 
-  /@netless/fastboard-core@1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41):
+  /@netless/fastboard-core@1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41):
     resolution: {integrity: sha512-y5Tp0I5Du8NvFQpg78+T60gazhfXXXUZXg2F7Yw5eSPb3hnG/Y16NIAFEzA+oAvfL93o6MbAIq8LLy8HlBGO3g==}
     peerDependencies:
       '@netless/window-manager': '>=1.0.0-canary.0'
@@ -3768,7 +3772,7 @@ packages:
     dependencies:
       '@lukeed/uuid': 2.0.0
       '@netless/synced-store': 2.0.7(white-web-sdk-esm@2.16.41)
-      '@netless/window-manager': 1.0.0-canary.76(white-web-sdk-esm@2.16.41)
+      '@netless/window-manager': 1.0.0-canary.77(white-web-sdk-esm@2.16.41)
       white-web-sdk: /white-web-sdk-esm@2.16.41
 
   /@netless/fastboard-ui@1.0.0-canary.8(@netless/fastboard-core@1.0.0-canary.8):
@@ -3776,10 +3780,10 @@ packages:
     peerDependencies:
       '@netless/fastboard-core': 1.0.0-canary.8
     dependencies:
-      '@netless/fastboard-core': 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41)
+      '@netless/fastboard-core': 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41)
       tippy.js: 6.3.7
 
-  /@netless/fastboard@1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41):
+  /@netless/fastboard@1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41):
     resolution: {integrity: sha512-9DQpm87m+RowXj+wzpGWuhSkdSsSRYnjY3j1PmpLbJe0+Od01EQTalKuBxesSXpUOSnWz6d0JLHrgshMJJr15g==}
     peerDependencies:
       '@netless/window-manager': '>=1.0.0-canary.0'
@@ -3791,9 +3795,9 @@ packages:
         optional: true
     dependencies:
       '@netless/app-slide': 0.3.0-canary.19
-      '@netless/fastboard-core': 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.76)(white-web-sdk-esm@2.16.41)
+      '@netless/fastboard-core': 1.0.0-canary.8(@netless/window-manager@1.0.0-canary.77)(white-web-sdk-esm@2.16.41)
       '@netless/fastboard-ui': 1.0.0-canary.8(@netless/fastboard-core@1.0.0-canary.8)
-      '@netless/window-manager': 1.0.0-canary.76(white-web-sdk-esm@2.16.41)
+      '@netless/window-manager': 1.0.0-canary.77(white-web-sdk-esm@2.16.41)
       white-web-sdk: /white-web-sdk-esm@2.16.41
 
   /@netless/mini-svg-data-uri@0.0.1:
@@ -3857,8 +3861,8 @@ packages:
       html2canvas: 1.4.1
     dev: false
 
-  /@netless/window-manager@1.0.0-canary.76(white-web-sdk-esm@2.16.41):
-    resolution: {integrity: sha512-pKIhbRumaC7MAZ7sS7nf/W/csmOZjvLk0g84+Kt3qGxEu8xPH5QDlb7zw0cytqtxsfmCz8psxQX2ox3HjHAkrw==}
+  /@netless/window-manager@1.0.0-canary.77(white-web-sdk-esm@2.16.41):
+    resolution: {integrity: sha512-RPXvYONZH5J1gketAutNQk1aPZA9A4KN2hLKguxhLrsdxgfIPO9T538hYJSRtCqovDqKv+Ise27moDlwturn6A==}
     peerDependencies:
       white-web-sdk: ^2.16.0
     peerDependenciesMeta:

--- a/service-providers/fastboard/package.json
+++ b/service-providers/fastboard/package.json
@@ -16,7 +16,7 @@
     "@netless/flat-service-provider-file-convert-netless": "workspace:*",
     "@netless/flat-services": "workspace:*",
     "@netless/white-snapshot": "^0.4.2",
-    "@netless/window-manager": "1.0.0-canary.76",
+    "@netless/window-manager": "1.0.0-canary.77",
     "side-effect-manager": "^1.2.1",
     "value-enhancer": "^1.3.2",
     "white-web-sdk": "npm:white-web-sdk-esm@2.16.41"


### PR DESCRIPTION
- fix: disable global keyboard shortcuts in docs viewer when
       focusing on editable elements like text area
