### PR TITLE
perf(flat-stores): fetch users info only when necessary

### DIFF
--- a/packages/flat-components/src/components/LoginPage/LoginWithPhone/index.tsx
+++ b/packages/flat-components/src/components/LoginPage/LoginWithPhone/index.tsx
@@ -229,6 +229,28 @@ export const LoginWithPhone: React.FC<LoginWithPhoneProps> = ({
             <div className="login-with-phone">
                 <div className="login-width-limiter">
                     <LoginTitle />
+                    {process.env.DEV ? (
+                        <select
+                            style={{
+                                position: "absolute",
+                                height: 32,
+                                transform: "translateX(-120%)",
+                                opacity: 0,
+                                cursor: "pointer",
+                            }}
+                            onChange={ev => {
+                                setPhone(ev.currentTarget.value);
+                                setCode("666666");
+                                setAgreed(true);
+                            }}
+                        >
+                            {Array.from({ length: 9 }, (_, i) => (
+                                <option key={i} value={"13" + String(i + 1).repeat(9)}>
+                                    13{i + 1}
+                                </option>
+                            ))}
+                        </select>
+                    ) : null}
                     <Input
                         placeholder={t("enter-phone")}
                         prefix={

--- a/packages/flat-components/src/components/MainPageLayout/MainPageTopBar/WindowsSystemBtn/style.less
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageTopBar/WindowsSystemBtn/style.less
@@ -10,7 +10,8 @@
     margin-right: 5px;
     padding: 4px;
     border-radius: 8px;
-    cursor: unset;
+    cursor: default;
+    z-index: 9999;
 
     &:hover {
         background-color: var(--blue-1);

--- a/packages/flat-pages/src/components/UsersButton.tsx
+++ b/packages/flat-pages/src/components/UsersButton.tsx
@@ -19,7 +19,12 @@ export const UsersButton = observer<UsersButtonProps>(function UsersButton({ cla
     const users = useComputed(() => {
         const { offlineJoiners } = classroom;
         const { speakingJoiners, handRaisingJoiners, otherJoiners } = classroom.users;
-        return [...speakingJoiners, ...handRaisingJoiners, ...offlineJoiners, ...otherJoiners].sort(
+
+        // speaking users may include offline users, so filter them out
+        const offlineUserUUIDs = new Set(offlineJoiners.map(user => user.userUUID));
+        const speakingOnline = speakingJoiners.filter(user => !offlineUserUUIDs.has(user.userUUID));
+
+        return [...speakingOnline, ...handRaisingJoiners, ...offlineJoiners, ...otherJoiners].sort(
             (a, b) => a.name.localeCompare(b.name),
         );
     }).get();

--- a/packages/flat-server-api/src/room.ts
+++ b/packages/flat-server-api/src/room.ts
@@ -376,12 +376,10 @@ export interface UsersInfoPayload {
     usersUUID?: string[];
 }
 
+export type UserInfo = { name: string; rtcUID: number; avatarURL: string };
+
 export type UsersInfoResult = {
-    [key in string]: {
-        name: string;
-        rtcUID: number;
-        avatarURL: string;
-    };
+    [key in string]: UserInfo;
 };
 
 export function usersInfo(payload: UsersInfoPayload): Promise<UsersInfoResult> {

--- a/packages/flat-services/src/services/text-chat/commands.ts
+++ b/packages/flat-services/src/services/text-chat/commands.ts
@@ -1,4 +1,4 @@
-import type { RoomStatus } from "@netless/flat-server-api";
+import type { RoomStatus, UserInfo } from "@netless/flat-server-api";
 
 /** From teacher to students */
 export interface IServiceTextChatRoomCommandData {
@@ -6,6 +6,9 @@ export interface IServiceTextChatRoomCommandData {
     "ban": { roomUUID: string; status: boolean };
     "notice": { roomUUID: string; text: string };
     "reward": { roomUUID: string; userUUID: string };
+    // Everyone, send this message on join room
+    // Users that in 'peers' should send back the 'users-info' command
+    "enter": { roomUUID: string; userUUID: string; userInfo: UserInfo; peers?: string[] };
 }
 
 export type IServiceTextChatRoomCommandNames = keyof IServiceTextChatRoomCommandData;
@@ -25,6 +28,8 @@ export interface IServiceTextChatPeerCommandData {
     "request-device-response": { roomUUID: string; camera?: boolean; mic?: boolean };
     /** From teacher to student */
     "notify-device-off": { roomUUID: string; camera?: false; mic?: false };
+    /** From everyone to everyone, should send this when received 'enter' command above */
+    "users-info": { roomUUID: string; users: Record<string, UserInfo> };
 }
 
 export type IServiceTextChatPeerCommandNames = keyof IServiceTextChatPeerCommandData;

--- a/packages/flat-services/src/services/text-chat/events.ts
+++ b/packages/flat-services/src/services/text-chat/events.ts
@@ -1,4 +1,4 @@
-import type { RoomStatus } from "@netless/flat-server-api";
+import type { RoomStatus, UserInfo } from "@netless/flat-server-api";
 import type { Remitter } from "remitter";
 
 export interface IServiceTextChatEventData {
@@ -48,6 +48,13 @@ export interface IServiceTextChatEventData {
         senderID: string;
         deviceState: { camera?: boolean; mic?: boolean };
     };
+    "enter": {
+        roomUUID: string;
+        userUUID: string;
+        userInfo: UserInfo;
+        peers?: string[];
+    };
+    "users-info": { roomUUID: string; userUUID: string; users: Record<string, UserInfo> };
 }
 
 export type IServiceTextChatEventNames = Extract<keyof IServiceTextChatEventData, string>;

--- a/packages/flat-stores/src/classroom-store/index.ts
+++ b/packages/flat-stores/src/classroom-store/index.ts
@@ -565,7 +565,7 @@ export class ClassroomStore {
             const onStageUsers = Object.keys(onStageUsersStorage.state).filter(
                 userUUID => onStageUsersStorage.state[userUUID],
             );
-            await this.users.syncExtraUsersInfo(onStageUsers);
+            await this.users.flushLazyUsers(onStageUsers);
             runInAction(() => {
                 this.onStageUserUUIDs.replace(onStageUsers);
             });

--- a/packages/flat-stores/src/classroom-store/index.ts
+++ b/packages/flat-stores/src/classroom-store/index.ts
@@ -806,28 +806,30 @@ export class ClassroomStore {
         }
     }
 
-    private sendUsersInfoToPeer(userUUID: string): void {
-        const users: Record<string, UserInfo> = {};
-
+    // @TODO: use RTM 2.0 and get users info from peer properties
+    private sendUsersInfoToPeer(_userUUID: string): void {
+        // @TODO: disabled for now, be cause RTM 1.0 has a limit of 1KB per message
+        //
+        // const users: Record<string, UserInfo> = {};
+        //
         // Filter out initialized users (whose rtcUID is not null)
-        for (const user of this.users.cachedUsers.values()) {
-            if (user.rtcUID) {
-                users[user.userUUID] = {
-                    rtcUID: +user.rtcUID || 0,
-                    name: user.name,
-                    avatarURL: user.avatar,
-                };
-            }
-        }
-
-        void this.rtm.sendPeerCommand(
-            "users-info",
-            {
-                roomUUID: this.roomUUID,
-                users,
-            },
-            userUUID,
-        );
+        // for (const user of this.users.cachedUsers.values()) {
+        //     if (user.rtcUID) {
+        //         users[user.userUUID] = {
+        //             rtcUID: +user.rtcUID || 0,
+        //             name: user.name,
+        //             avatarURL: user.avatar,
+        //         };
+        //     }
+        // }
+        // void this.rtm.sendPeerCommand(
+        //     "users-info",
+        //     {
+        //         roomUUID: this.roomUUID,
+        //         users,
+        //     },
+        //     userUUID,
+        // );
     }
 
     public async destroy(): Promise<void> {

--- a/packages/flat-stores/src/classroom-store/index.ts
+++ b/packages/flat-stores/src/classroom-store/index.ts
@@ -10,7 +10,6 @@ import {
     RoomStatus,
     RoomType,
     checkRTMCensor,
-    UserInfo,
 } from "@netless/flat-server-api";
 import { FlatI18n } from "@netless/flat-i18n";
 import { errorTips, message } from "flat-components";

--- a/packages/flat-stores/src/room-store.ts
+++ b/packages/flat-stores/src/room-store.ts
@@ -21,7 +21,6 @@ import {
     recordInfo,
     RoomStatus,
     RoomType,
-    usersInfo,
 } from "@netless/flat-server-api";
 import { globalStore } from "./global-store";
 import { preferencesStore } from "./preferences-store";
@@ -133,16 +132,10 @@ export class RoomStore {
 
     public async syncOrdinaryRoomInfo(roomUUID: string): Promise<void> {
         const { roomInfo, ...restInfo } = await ordinaryRoomInfo(roomUUID);
-        // always include owner avatar url in full room info
-        const { [roomInfo.ownerUUID]: owner } = await usersInfo({
-            roomUUID,
-            usersUUID: [roomInfo.ownerUUID],
-        });
         this.updateRoom(roomUUID, roomInfo.ownerUUID, {
             ...restInfo,
             ...roomInfo,
             roomUUID,
-            ownerAvatarURL: owner.avatarURL,
         });
     }
 

--- a/packages/flat-stores/src/user-store.ts
+++ b/packages/flat-stores/src/user-store.ts
@@ -203,11 +203,18 @@ export class UserStore {
     };
 
     /**
-     * Fetch info of lazily initialized users.
+     * Fetch info of lazily initialized users, or create new one if not exist.
      */
-    public flushLazyUsers = async (userUUIDs?: string[]): Promise<void> => {
-        if (!userUUIDs) {
-            userUUIDs = [];
+    public flushLazyUsers = async (wanted?: string[]): Promise<void> => {
+        const userUUIDs: string[] = [];
+        if (wanted) {
+            for (const userUUID of wanted) {
+                const user = this.cachedUsers.get(userUUID);
+                if (!user || !user.rtcUID) {
+                    userUUIDs.push(userUUID);
+                }
+            }
+        } else {
             for (const user of this.cachedUsers.values()) {
                 if (!user.rtcUID) {
                     userUUIDs.push(user.userUUID);

--- a/packages/flat-stores/src/user-store.ts
+++ b/packages/flat-stores/src/user-store.ts
@@ -116,18 +116,22 @@ export class UserStore {
         return user;
     };
 
-    public cacheUserIfNeeded = (userUUID: string, userInfo: UserInfo): void => {
+    // Returns `true` if user info is updated.
+    public cacheUserIfNeeded = (userUUID: string, userInfo: UserInfo): boolean => {
         let user = this.cachedUsers.get(userUUID);
         if (!user) {
             user = this.createLazyUsers([userUUID])[0];
             this.cacheUser(user);
             this.sortUser(user);
         }
+        let updated = false;
         if (!user.rtcUID) {
             user.name = userInfo.name;
             user.avatar = userInfo.avatarURL;
             user.rtcUID = String(userInfo.rtcUID);
+            updated = true;
         }
+        return updated;
     };
 
     public removeUser = (userUUID: string): void => {

--- a/packages/flat-stores/src/user-store.ts
+++ b/packages/flat-stores/src/user-store.ts
@@ -1,5 +1,5 @@
 import { action, makeAutoObservable, observable } from "mobx";
-import { usersInfo, CloudRecordStartPayload } from "@netless/flat-server-api";
+import { usersInfo, CloudRecordStartPayload, UserInfo } from "@netless/flat-server-api";
 import { preferencesStore } from "./preferences-store";
 import { isEmpty } from "lodash-es";
 
@@ -107,6 +107,18 @@ export class UserStore {
             user = this.createLazyUsers([userUUID], true)[0];
         }
         return user;
+    };
+
+    public cacheUserIfNeeded = (userUUID: string, userInfo: UserInfo): void => {
+        let user = this.cachedUsers.get(userUUID);
+        if (!user) {
+            user = this.createLazyUsers([userUUID])[0];
+        }
+        if (!user.rtcUID) {
+            user.name = userInfo.name;
+            user.avatar = userInfo.avatarURL;
+            user.rtcUID = String(userInfo.rtcUID);
+        }
     };
 
     public removeUser = (userUUID: string): void => {

--- a/service-providers/agora-rtm/src/rtm.ts
+++ b/service-providers/agora-rtm/src/rtm.ts
@@ -231,15 +231,15 @@ export class AgoraRTM extends IServiceTextChat {
                         break;
                     }
                     case RtmEngine.MessageType.RAW: {
-                        if (senderID === ownerUUID) {
-                            try {
-                                const command = JSON.parse(
-                                    new TextDecoder().decode(msg.rawMessage),
-                                ) as IServiceTextChatRoomCommand;
+                        try {
+                            const command = JSON.parse(
+                                new TextDecoder().decode(msg.rawMessage),
+                            ) as IServiceTextChatRoomCommand;
+                            if (senderID === ownerUUID || command.t === "enter") {
                                 this._emitRoomCommand(roomUUID, senderID, command);
-                            } catch (e) {
-                                console.error(e);
                             }
+                        } catch (e) {
+                            console.error(e);
                         }
                         break;
                     }
@@ -289,6 +289,14 @@ export class AgoraRTM extends IServiceTextChat {
                                     roomUUID,
                                     senderID,
                                     deviceState: command.v,
+                                });
+                                break;
+                            }
+                            case "users-info": {
+                                this.events.emit("users-info", {
+                                    roomUUID,
+                                    userUUID: senderID,
+                                    users: command.v.users,
                                 });
                                 break;
                             }
@@ -373,6 +381,15 @@ export class AgoraRTM extends IServiceTextChat {
                     roomUUID,
                     userUUID: command.v.userUUID,
                     senderID: ownerUUID,
+                });
+                break;
+            }
+            case "enter": {
+                this.events.emit("enter", {
+                    roomUUID,
+                    userUUID: command.v.userUUID,
+                    userInfo: command.v.userInfo,
+                    peers: command.v.peers,
                 });
                 break;
             }

--- a/service-providers/agora-rtm/src/rtm.ts
+++ b/service-providers/agora-rtm/src/rtm.ts
@@ -16,6 +16,8 @@ import { v4 as uuidv4 } from "uuid";
 export class AgoraRTM extends IServiceTextChat {
     public readonly members = new Set<string>();
 
+    private readonly _encoder = new TextEncoder();
+    private readonly _decoder = new TextDecoder();
     private readonly _sideEffect = new SideEffectManager();
     private readonly _roomSideEffect = new SideEffectManager();
 
@@ -131,7 +133,7 @@ export class AgoraRTM extends IServiceTextChat {
             const command = { t, v } as IServiceTextChatRoomCommand;
             await this.channel.sendMessage({
                 messageType: RtmEngine.MessageType.RAW,
-                rawMessage: new TextEncoder().encode(JSON.stringify(command)),
+                rawMessage: this._encoder.encode(JSON.stringify(command)),
             });
             // emit to local
             if (this.roomUUID && this.userUUID) {
@@ -165,7 +167,7 @@ export class AgoraRTM extends IServiceTextChat {
             const result = await this.client.sendMessageToPeer(
                 {
                     messageType: RtmEngine.MessageType.RAW,
-                    rawMessage: new TextEncoder().encode(JSON.stringify({ t, v })),
+                    rawMessage: this._encoder.encode(JSON.stringify({ t, v })),
                 },
                 peerID,
             );
@@ -233,7 +235,7 @@ export class AgoraRTM extends IServiceTextChat {
                     case RtmEngine.MessageType.RAW: {
                         try {
                             const command = JSON.parse(
-                                new TextDecoder().decode(msg.rawMessage),
+                                this._decoder.decode(msg.rawMessage),
                             ) as IServiceTextChatRoomCommand;
                             if (senderID === ownerUUID || command.t === "enter") {
                                 this._emitRoomCommand(roomUUID, senderID, command);
@@ -254,7 +256,7 @@ export class AgoraRTM extends IServiceTextChat {
                 if (msg.messageType === RtmEngine.MessageType.RAW) {
                     try {
                         const command = JSON.parse(
-                            new TextDecoder().decode(msg.rawMessage),
+                            this._decoder.decode(msg.rawMessage),
                         ) as IServiceTextChatPeerCommand;
                         if (command.v.roomUUID !== roomUUID) {
                             return;


### PR DESCRIPTION
New RTM commands @netless-io/native

Broadcast Command **"enter"**: Tell everyone in the room your basic info (name, avatar, rtcUID); pick up to 3 peers to tell you everyone else's info, see the next command.

```js
onJoinRoom((rtm) => {
    rtm.sendRoomCommand("enter", {
        roomUUID: this.roomUUID,
        userUUID: user.userUUID,
        userInfo: {
            name: user.name,
            avatarURL: user.avatar,
            rtcUID: +user.rtcUID || 0,
        },
        peers: sampleSize(rtm.members, 3),
    })
})

onRoomCommand("enter", ({ userUUID, userInfo }) => {
    usersStore.cacheUser(userUUID, userInfo)
})
```

<details><summary>Disabled "users-info" command for now because of the limitation of RTM</summary>

Peer Command **"users-info"**: Tell someone all of the local users' info.

```ts
onRoomCommand("enter", ({ userUUID: senderID, peers }) => {
    if (peers.includes(this.userUUID)) {
        rtm.sendPeerCommand("users-info", {
            roomUUID: this.roomUUID,
            users: getAllLocalUsers(),
        }, senderID)
    }
})

// The return value is the same as the /room/info/users server API.
declare function getAllLocalUsers(): {
    [userUUID: string]: {
        rtcUID: number,
        name: string,
        avatarURL: string,
    }
}

onPeerCommand("users-info", ({ users }) => {
    usersStore.cacheUsers(users)
})
```

</details>
