### PR TITLE
refactor(flat-server-api): choose server by room's region

### DIFF
--- a/packages/flat-server-api/src/error.ts
+++ b/packages/flat-server-api/src/error.ts
@@ -154,7 +154,7 @@ export class ServerRequestError extends Error {
     public errorMessage: string;
 
     public constructor(errorCode: RequestErrorCode) {
-        super(`request failed: ${errorCode}`);
+        super(`request failed: ${errorCode} (${RequestErrorCode[errorCode]})`);
         this.name = this.constructor.name;
         this.errorCode = errorCode;
         this.errorMessage = RequestErrorMessage[errorCode];

--- a/packages/flat-server-api/src/utils.ts
+++ b/packages/flat-server-api/src/utils.ts
@@ -44,7 +44,14 @@ export function chooseServer(payload: any, enableFlatServerV2?: boolean): string
             if ((uuid.length === 11 && uuid[0] === "2") || uuid.startsWith("SG-")) {
                 region = Region.SG;
             }
+            // Legacy room
+            if (uuid.length === 10) {
+                region = Region.CN_HZ;
+            }
         }
+    }
+    if (region === defaultRegion) {
+        return server;
     }
 
     // replace the left most part of domain, currently we have "{api}" for cn-hz, "{api}-sg" for sg

--- a/packages/flat-server-api/src/utils.ts
+++ b/packages/flat-server-api/src/utils.ts
@@ -33,7 +33,7 @@ export function chooseServer(payload: any, enableFlatServerV2?: boolean): string
 
     let region = defaultRegion;
     if (payload !== null && typeof payload === "object") {
-        // Please check all server api's payload to make sure roomUUID is from these fields
+        // Please check all server api's payload to make sure roomUUID is from the fields: roomUUID, uuid
         // the "uuid" is maybe an invite code
         const uuid = payload.roomUUID || payload.uuid;
 
@@ -102,7 +102,6 @@ export async function requestFlatServer<TPayload, TResult>(
         headers.set("authorization", "Bearer " + token);
     }
 
-    // TODO: if payload.roomUUID has '{REGION}-' prefix, select another server
     const response = await fetch(`${chooseServer(payload, enableFlatServerV2)}/${action}`, config);
 
     if (!response.ok) {

--- a/packages/flat-server-api/src/utils.ts
+++ b/packages/flat-server-api/src/utils.ts
@@ -1,4 +1,4 @@
-import { FLAT_SERVER_BASE_URL_V1, FLAT_SERVER_BASE_URL_V2, Status } from "./constants";
+import { FLAT_SERVER_BASE_URL_V1, FLAT_SERVER_BASE_URL_V2, Region, Status } from "./constants";
 import { ServerRequestError, RequestErrorCode } from "./error";
 import { v4 as uuidv4 } from "uuid";
 
@@ -24,6 +24,43 @@ export type FlatServerRawResponseData<T> =
 export function setFlatAuthToken(token: string): void {
     authToken = token;
     localStorage.setItem("FlatAuthToken", token);
+}
+
+const defaultRegion = FLAT_SERVER_BASE_URL_V1.includes("-sg") ? Region.SG : Region.CN_HZ;
+
+export function chooseServer(payload: any, enableFlatServerV2?: boolean): string {
+    let server = enableFlatServerV2 ? FLAT_SERVER_BASE_URL_V2 : FLAT_SERVER_BASE_URL_V1;
+
+    let region = defaultRegion;
+    if (payload !== null && typeof payload === "object") {
+        // Please check all server api's payload to make sure roomUUID is from these fields
+        // the "uuid" is maybe an invite code
+        const uuid = payload.roomUUID || payload.uuid;
+
+        if (typeof uuid === "string") {
+            if ((uuid.length === 11 && uuid[0] === "1") || uuid.startsWith("CN-")) {
+                region = Region.CN_HZ;
+            }
+            if ((uuid.length === 11 && uuid[0] === "2") || uuid.startsWith("SG-")) {
+                region = Region.SG;
+            }
+        }
+    }
+
+    // replace the left most part of domain, currently we have "{api}" for cn-hz, "{api}-sg" for sg
+    server = server.replace(/^https:\/\/([-\w]+)/, (_, name: string) => {
+        // normalize
+        if (name.endsWith("-sg")) {
+            name = name.slice(0, -3);
+        }
+        // add suffix if needed
+        if (region === Region.SG) {
+            name += "-sg";
+        }
+        return `https://${name}`;
+    });
+
+    return server;
 }
 
 export async function requestFlatServer<TPayload, TResult>(
@@ -59,12 +96,7 @@ export async function requestFlatServer<TPayload, TResult>(
     }
 
     // TODO: if payload.roomUUID has '{REGION}-' prefix, select another server
-    const response = await fetch(
-        `${
-            enableFlatServerV2 === true ? FLAT_SERVER_BASE_URL_V2 : FLAT_SERVER_BASE_URL_V1
-        }/${action}`,
-        config,
-    );
+    const response = await fetch(`${chooseServer(payload, enableFlatServerV2)}/${action}`, config);
 
     if (!response.ok) {
         // @TODO create a timeout error code


### PR DESCRIPTION
This PR can be merged and published after server side published.

During the time before the frontend releasing, users could failed to "join room" through the join room box, because that UI enforces some rules on room UUID. But they can still join the page via entering full UUID or paste the URL.

Need native end double check @netless-io/native 