### PR TITLE
style(project): adjust setting & sub menu style

### DIFF
--- a/packages/flat-components/src/components/MainPageLayout/MainPageSubMenu/style.less
+++ b/packages/flat-components/src/components/MainPageLayout/MainPageSubMenu/style.less
@@ -1,9 +1,6 @@
 .main-layout-sub-menu {
     width: 240px;
     border-right: solid 1px #dbe1ea;
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
-    overflow: hidden;
     background-color: #fff;
 
     ul {

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
@@ -92,7 +92,7 @@
 
 .join-room-settings {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr) 1.5fr;
     grid-gap: 8px;
     justify-items: start;
 


### PR DESCRIPTION
The purpose of removing those lines is to fix a sidebar style error in electron that looks very strange in electron.
```diff
  .main-layout-sub-menu {
      width: 240px;
      border-right: solid 1px #dbe1ea;
-     border-top-left-radius: 6px;
-     border-bottom-left-radius: 6px;
-     overflow: hidden;
      background-color: #fff;
      ...
}
```
