### PR TITLE
chore(library): upgrade @netless/app-slide to 0.3.0-canary.20

### DIFF
--- a/desktop/renderer-app/package.json
+++ b/desktop/renderer-app/package.json
@@ -22,7 +22,7 @@
     "@netless/app-monaco": "0.2.0-canary.1",
     "@netless/app-quill": "^0.1.2",
     "@netless/app-selector": "^0.0.3",
-    "@netless/app-slide": "0.3.0-canary.19",
+    "@netless/app-slide": "0.3.0-canary.20",
     "@netless/flat-i18n": "workspace:*",
     "@netless/flat-pages": "workspace:*",
     "@netless/flat-stores": "workspace:*",

--- a/packages/flat-pages/package.json
+++ b/packages/flat-pages/package.json
@@ -8,7 +8,7 @@
     "@netless/app-geogebra": "^0.0.6",
     "@netless/app-iframe-bridge": "^0.0.2",
     "@netless/app-monaco": "0.2.0-canary.1",
-    "@netless/app-slide": "0.3.0-canary.19",
+    "@netless/app-slide": "0.3.0-canary.20",
     "@netless/flat-i18n": "workspace:*",
     "@netless/flat-server-api": "workspace:*",
     "@netless/flat-service-provider-agora-rtc-web": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,8 +247,8 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(ts-node@10.9.1)
       '@netless/app-slide':
-        specifier: 0.3.0-canary.19
-        version: 0.3.0-canary.19
+        specifier: 0.3.0-canary.20
+        version: 0.3.0-canary.20
       '@netless/flat-i18n':
         specifier: workspace:*
         version: link:../../packages/flat-i18n
@@ -598,8 +598,8 @@ importers:
         specifier: 0.2.0-canary.1
         version: 0.2.0-canary.1
       '@netless/app-slide':
-        specifier: 0.3.0-canary.19
-        version: 0.3.0-canary.19
+        specifier: 0.3.0-canary.20
+        version: 0.3.0-canary.20
       '@netless/flat-i18n':
         specifier: workspace:*
         version: link:../flat-i18n
@@ -1026,8 +1026,8 @@ importers:
   service-providers/file-preview-netless-slide:
     dependencies:
       '@netless/app-slide':
-        specifier: 0.3.0-canary.19
-        version: 0.3.0-canary.19
+        specifier: 0.3.0-canary.20
+        version: 0.3.0-canary.20
       '@netless/flat-server-api':
         specifier: workspace:*
         version: link:../../packages/flat-server-api
@@ -1078,8 +1078,8 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(ts-node@10.9.1)
       '@netless/app-slide':
-        specifier: 0.3.0-canary.19
-        version: 0.3.0-canary.19
+        specifier: 0.3.0-canary.20
+        version: 0.3.0-canary.20
       '@netless/flat-i18n':
         specifier: workspace:*
         version: link:../../packages/flat-i18n
@@ -3709,10 +3709,10 @@ packages:
       - ts-node
     dev: false
 
-  /@netless/app-slide@0.3.0-canary.19:
-    resolution: {integrity: sha512-xyyp4GLoh9iwz6UBQM/qFbemThmUaCfovg3sp+KDmPgyNq/huwMYeBPvoMJivAbOjsLHWMwPqaIgFrdiTOBucw==}
+  /@netless/app-slide@0.3.0-canary.20:
+    resolution: {integrity: sha512-FKUnHV9uK/8erSlE3Lvdf7mOk+Nhh25USwBd+njm4zIb/9YJr1GCuNxkyMQmvNnk3SFqNx7GvpeTidiEURQXDg==}
     dependencies:
-      '@netless/slide': 1.1.2
+      '@netless/slide': 1.1.6
       jspdf: 2.5.1
 
   /@netless/canvas-polyfill@0.0.4:
@@ -3763,7 +3763,7 @@ packages:
       white-web-sdk:
         optional: true
     dependencies:
-      '@netless/app-slide': 0.3.0-canary.19
+      '@netless/app-slide': 0.3.0-canary.20
       '@netless/fastboard-core': 1.0.0-canary.9(@netless/window-manager@1.0.0-canary.79)(white-web-sdk-esm@2.16.44)
       '@netless/fastboard-ui': 1.0.0-canary.9(@netless/fastboard-core@1.0.0-canary.9)
       '@netless/window-manager': 1.0.0-canary.79(white-web-sdk-esm@2.16.44)
@@ -3774,8 +3774,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@netless/slide@1.1.2:
-    resolution: {integrity: sha512-16WaaE/EFZlDYeqmmokjCAQIS98KZcuXkB4e4sGxdHdrGDYLMIchKIqTEZYXddlQdJ3ezhUcJHJ01inGPlqeRA==}
+  /@netless/slide@1.1.6:
+    resolution: {integrity: sha512-0vTNTaRFE+qH5Yc9x0jifWqx4Qk3J0LhaMl0bk62T3ID4M5HRr+ppYJx3bsqeDp5XKMI/iA9dkRIgMKesaa8Ew==}
     dependencies:
       '@juggle/resize-observer': 3.4.0
       '@types/lodash': 4.14.185

--- a/service-providers/file-preview-netless-slide/package.json
+++ b/service-providers/file-preview-netless-slide/package.json
@@ -14,7 +14,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@netless/app-slide": "0.3.0-canary.19",
+    "@netless/app-slide": "0.3.0-canary.20",
     "@netless/flat-service-provider-file-convert-netless": "workspace:*",
     "@netless/flat-services": "workspace:*",
     "@netless/flat-server-api": "workspace:*"

--- a/web/flat-web/package.json
+++ b/web/flat-web/package.json
@@ -22,7 +22,7 @@
     "@netless/app-monaco": "0.2.0-canary.1",
     "@netless/app-quill": "^0.1.2",
     "@netless/app-selector": "^0.0.3",
-    "@netless/app-slide": "0.3.0-canary.19",
+    "@netless/app-slide": "0.3.0-canary.20",
     "@netless/flat-i18n": "workspace:*",
     "@netless/flat-pages": "workspace:*",
     "@netless/flat-server-api": "workspace:*",


### PR DESCRIPTION
- hide whiteboard on switching pages
