### PR TITLE
refactor(flat-pages): allow controlling apps in replay mode

### DIFF
--- a/packages/flat-pages/src/ReplayPage/ReplayPage.less
+++ b/packages/flat-pages/src/ReplayPage/ReplayPage.less
@@ -57,6 +57,7 @@
 
 .replay-share-screen {
     z-index: 3;
+    display: none;
 }
 
 .replay-bottom {


### PR DESCRIPTION
Note: currently the `replay-share-screen` div is not used since we
do not record the share screen stream.
