### PR TITLE
refactor(style): adjust style

### DIFF
--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
@@ -174,7 +174,7 @@ export const EditRoomBody: React.FC<EditRoomBodyProps> = ({
                         {renderEndTimePicker(t, form, nextPeriodicRoomEndTime)}
                         {showPmi && updateAutoPmiOn && (
                             <Form.Item
-                                className="edit-room-form-item no-margin"
+                                className="edit-room-form-item no-margin pmi"
                                 name="pmi"
                                 valuePropName="checked"
                             >
@@ -188,8 +188,8 @@ export const EditRoomBody: React.FC<EditRoomBodyProps> = ({
                                         pmi={pmi!}
                                         text={t("turn-on-the-pmi")}
                                     />
-                                    {pmiRoomExist && <PmiExistTip />}
                                 </Checkbox>
+                                {pmiRoomExist && <PmiExistTip />}
                             </Form.Item>
                         )}
                         {type === "schedule" ? (

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/index.tsx
@@ -178,18 +178,20 @@ export const EditRoomBody: React.FC<EditRoomBodyProps> = ({
                                 name="pmi"
                                 valuePropName="checked"
                             >
-                                <Checkbox
-                                    checked={autoPmiOn}
-                                    disabled={pmiRoomExist}
-                                    onClick={() => updateAutoPmiOn(!autoPmiOn)}
-                                >
-                                    <PmiDesc
-                                        className="edit-room-cycle"
-                                        pmi={pmi!}
-                                        text={t("turn-on-the-pmi")}
-                                    />
-                                </Checkbox>
-                                {pmiRoomExist && <PmiExistTip />}
+                                <div>
+                                    <Checkbox
+                                        checked={autoPmiOn}
+                                        disabled={pmiRoomExist}
+                                        onClick={() => updateAutoPmiOn(!autoPmiOn)}
+                                    >
+                                        <PmiDesc
+                                            className="edit-room-cycle"
+                                            pmi={pmi!}
+                                            text={t("turn-on-the-pmi")}
+                                        />
+                                    </Checkbox>
+                                    {pmiRoomExist && <PmiExistTip />}
+                                </div>
                             </Form.Item>
                         )}
                         {type === "schedule" ? (

--- a/packages/flat-components/src/components/EditRoomPage/EditRoomBody/style.less
+++ b/packages/flat-components/src/components/EditRoomPage/EditRoomBody/style.less
@@ -26,6 +26,10 @@
     .edit-room-form-item.no-margin {
         margin-bottom: 0;
     }
+
+    .edit-room-form-item.pmi .ant-checkbox + span {
+        padding-right: 0;
+    }
 }
 
 .edit-room-box {
@@ -106,7 +110,7 @@
 .edit-room-cycle {
     font-size: 12px;
     font-weight: 400;
-    color: #7a7b7c;
+    color: var(--grey-6);
 }
 
 .edit-room-under {

--- a/packages/flat-components/src/components/Pmi/PmiExistTip/style.less
+++ b/packages/flat-components/src/components/Pmi/PmiExistTip/style.less
@@ -2,3 +2,9 @@
     margin-left: 4px;
     cursor: help;
 }
+
+// maybe we should not set `max-width` for `.ant-tooltip` in global?
+// it causes we should reset `max-width: none` everywhere!
+.pmi-room-help+div div .ant-tooltip {
+    max-width: none;
+}

--- a/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.less
+++ b/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.less
@@ -13,6 +13,10 @@
                 .main-room-menu-form-item.no-margin {
                     margin: 0
                 }
+
+                .main-room-menu-form-item.pmi .ant-checkbox+span {
+                    padding-right: 0;
+                }
             }
 
             >.ant-modal-footer {

--- a/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.tsx
+++ b/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.tsx
@@ -234,22 +234,24 @@ export const CreateRoomBox = observer<CreateRoomBoxProps>(function CreateRoomBox
                                 name="pmi"
                                 valuePropName="checked"
                             >
-                                <Checkbox
-                                    checked={preferencesStore.autoPmiOn}
-                                    disabled={globalStore.pmiRoomExist}
-                                    onClick={() =>
-                                        preferencesStore.updateAutoPmiOn(
-                                            !preferencesStore.autoPmiOn,
-                                        )
-                                    }
-                                >
-                                    <PmiDesc
-                                        className="checkbox-item-inner"
-                                        pmi={globalStore.pmi}
-                                        text={t("turn-on-the-pmi")}
-                                    />
-                                </Checkbox>
-                                {globalStore.pmiRoomExist && <PmiExistTip />}
+                                <div>
+                                    <Checkbox
+                                        checked={preferencesStore.autoPmiOn}
+                                        disabled={globalStore.pmiRoomExist}
+                                        onClick={() =>
+                                            preferencesStore.updateAutoPmiOn(
+                                                !preferencesStore.autoPmiOn,
+                                            )
+                                        }
+                                    >
+                                        <PmiDesc
+                                            className="checkbox-item-inner"
+                                            pmi={globalStore.pmi}
+                                            text={t("turn-on-the-pmi")}
+                                        />
+                                    </Checkbox>
+                                    {globalStore.pmiRoomExist && <PmiExistTip />}
+                                </div>
                             </Form.Item>
                         )}
                     </Form.Item>

--- a/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.tsx
+++ b/packages/flat-pages/src/HomePage/MainRoomMenu/CreateRoomBox.tsx
@@ -230,7 +230,7 @@ export const CreateRoomBox = observer<CreateRoomBoxProps>(function CreateRoomBox
                         </Form.Item>
                         {globalStore.pmi && (
                             <Form.Item
-                                className="main-room-menu-form-item no-margin"
+                                className="main-room-menu-form-item no-margin pmi"
                                 name="pmi"
                                 valuePropName="checked"
                             >
@@ -248,8 +248,8 @@ export const CreateRoomBox = observer<CreateRoomBoxProps>(function CreateRoomBox
                                         pmi={globalStore.pmi}
                                         text={t("turn-on-the-pmi")}
                                     />
-                                    {globalStore.pmiRoomExist && <PmiExistTip />}
                                 </Checkbox>
+                                {globalStore.pmiRoomExist && <PmiExistTip />}
                             </Form.Item>
                         )}
                     </Form.Item>

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/EditableInput.tsx
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/EditableInput.tsx
@@ -47,7 +47,7 @@ export function EditableInput({
         <div
             className={`input-container-bg${
                 hovering && !editing ? " input-container-bg-hover" : ""
-            }${editing ? " input-container-bg-editing" : ""}`}
+            }`}
             onMouseEnter={() => setHovering(true)}
             onMouseLeave={() => setHovering(false)}
         >

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/EditableInput.tsx
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/EditableInput.tsx
@@ -45,9 +45,11 @@ export function EditableInput({
 
     return (
         <div
-            className={`input-container-bg ${hovering ? "input-container-bg-hover" : ""}`}
+            className={`input-container-bg${
+                hovering && !editing ? " input-container-bg-hover" : ""
+            }${editing ? " input-container-bg-editing" : ""}`}
             onMouseEnter={() => setHovering(true)}
-            onMouseLeave={() => !editing && setHovering(false)}
+            onMouseLeave={() => setHovering(false)}
         >
             {icon && <img alt={icon} className="general-setting-item-icon" src={icon} />}
             <span className="general-setting-item-icon-desc">{desc}</span>

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/Google.tsx
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/Google.tsx
@@ -85,7 +85,7 @@ export const BindGoogle: React.FC<BindGoogleProps> = ({ name, isBind, onRefresh,
             title={isBind ? t("is-bind", { name }) : t("not-bind")}
             onClick={isBind ? unbind : bindGoogle}
         >
-            {GoogleSVG({ color: isBind ? undefined : "#5d6066" })}
+            {GoogleSVG({ binding: isBind })}
         </span>
     );
 };

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/icons/GoogleSVG.tsx
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/icons/GoogleSVG.tsx
@@ -1,6 +1,7 @@
+import "./index.less";
 import React from "react";
 
-export function GoogleSVG({ color }: { color: string | undefined }): React.ReactElement {
+export function GoogleSVG({ binding }: { binding: boolean }): React.ReactElement {
     const path = [
         {
             d: "M7.34525 12C7.34525 11.492 7.43192 11.0046 7.58525 10.548L4.89325 8.53465C4.35238 9.60963 4.07151 10.7966 4.07325 12C4.07325 13.2453 4.36792 14.42 4.89192 15.4626L7.58258 13.446C7.4257 12.98 7.34554 12.4917 7.34525 12Z",
@@ -20,14 +21,9 @@ export function GoogleSVG({ color }: { color: string | undefined }): React.React
         },
     ];
 
-    if (color) {
-        path.forEach(item => {
-            item.color = color;
-        });
-    }
-
     return (
         <svg
+            className={`binding-google-icon ${binding ? "" : "unbinding"}`}
             fill="none"
             height="24"
             viewBox="0 0 24 24"

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/icons/index.less
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/binding/icons/index.less
@@ -1,0 +1,3 @@
+.binding-google-icon.unbinding path {
+    fill: var(--grey-3);
+}

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
@@ -116,8 +116,8 @@
     display: inline-block;
     border-radius: 6px;
     transition: all 0.3s ease;
-    padding: 4px;
-    line-height: 38px;
+    padding: 6px;
+    line-height: 24px;
 
     img,
     span,
@@ -141,7 +141,13 @@
 
     .ant-btn-link {
         padding: 0;
+        height: auto;
     }
+}
+
+.input-container-bg-editing {
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 .input-container-bg-hover {

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
@@ -117,6 +117,7 @@
     border-radius: 6px;
     transition: all 0.3s ease;
     padding: 6px;
+    min-height: 38px;
     line-height: 24px;
 
     img,
@@ -126,6 +127,7 @@
     }
 
     .ant-input {
+        margin: -7px 0;
         width: 150px;
     }
 
@@ -143,11 +145,6 @@
         padding: 0;
         height: auto;
     }
-}
-
-.input-container-bg-editing {
-    padding-top: 0;
-    padding-bottom: 0;
 }
 
 .input-container-bg-hover {

--- a/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
+++ b/packages/flat-pages/src/UserSettingPage/GeneralSettingPage/index.less
@@ -35,10 +35,6 @@
 
     &-icon-desc {
         width: 150px;
-
-        .ant-tooltip {
-            max-width: none;
-        }
     }
 
     &-icon-desc-help {
@@ -158,7 +154,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--grey-6);
+    background-color: var(--grey-3);
     width: 24px;
     height: 24px;
     border-radius: 50%;


### PR DESCRIPTION
Removing the padding in the edit state causes the layout to recalculate and ‘flash up and down’. This seems inevitable? @hyrious 